### PR TITLE
Feat/write page: 이미지 썸네일 추가

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import ModifyPage from './src/pages/write/ModifyPage';
 import SavePage from './src/pages/write/save/SavePage';
 
 import {createPost, putPost} from './src/api/post.api';
+import {usePostStore} from './src/store/usePostStore';
 
 interface PostData {
   title: string;
@@ -56,6 +57,7 @@ const Stack = createStackNavigator<RootStackParamList>();
 export default function App() {
   const [postData, setPostData] = React.useState<PostData | null>(null);
   const [modifyData, setModifyData] = React.useState<ModifyData | null>(null);
+  const setPostResponse = usePostStore(state => state.setPostResponse); // Zustand의 상태 업데이트 함수
 
   const postTypeMapping: Record<string, string> = {
     '게시판 선택 안함': 'NO_SELECT',
@@ -68,21 +70,31 @@ export default function App() {
   const categoryMapping: Record<string, string> = {
     '카테고리 선택': 'NO_SELECT',
     '선택 안함': 'NO_SELECT',
+    '오페라 글라스': 'OPERA_GLASS_RENTAL',
+    '뮤지컬 용어': 'MUSICAL_TERMS',
+    이벤트: 'EVENTS',
     '시야 후기': 'VIEW_REVIEW',
     '굿즈 후기': 'GOODS_REVIEW',
     '공연 감상': 'PERFORMANCE_REVIEW',
   };
 
   const handleRegister = async (navigation, onRegistered) => {
+    const {setPostResponse, setImgUrls} = usePostStore.getState();
+
     if (postData) {
       const apiPostType =
         postTypeMapping[postData.post_type] || postData.post_type;
       const apiCategory =
         categoryMapping[postData.category] || postData.category;
 
-      console.log('전달받은 데이터: ', postData);
-      console.log('PostType: ', apiPostType);
-      console.log('Category: ', apiCategory);
+      console.log('전송 데이터: ', {
+        category: apiCategory,
+        post_type: apiPostType,
+        title: postData.title,
+        content: postData.content,
+        hashTags: postData.hashTags,
+        imgUrls: postData.imgUrls,
+      });
 
       try {
         const response = await createPost(
@@ -93,26 +105,33 @@ export default function App() {
           postData.hashTags,
           postData.imgUrls,
         );
-        console.log('API RESPONSE: ', response.data);
 
-        // 등록 성공 후 처리
+        console.log('서버 응답: ', response.data);
+
+        setPostResponse(response.data);
+
+        if (response.data?.data) {
+          setImgUrls(response.data.data, postData.imgUrls);
+        }
+
         if (response.status === 201 || response.status === 200) {
           console.log('글이 성공적으로 등록되었습니다!');
           alert('글이 성공적으로 등록되었습니다.');
-
-          // 등록 완료 후 뒤로가기 및 상태 갱신 트리거
-          onRegistered(); // 이전 컴포넌트에 상태 갱신 요청
-          setTimeout(() => {
-            navigation.goBack(); // 뒤로 가기
-          }, 500); // 약간의 지연 추가
+          onRegistered();
+          setTimeout(() => navigation.goBack(), 500);
         }
       } catch (error) {
-        console.log('Error:', error);
+        if (error.response) {
+          console.error('서버 오류 응답: ', error.response.data);
+        } else {
+          console.error('네트워크 또는 기타 오류: ', error.message);
+        }
       }
     } else {
-      console.log('No data from WritePage');
+      console.error('postData가 비어 있습니다.');
     }
   };
+
   // 글 작성 완료 후 새로고침
   const [refresh, setRefresh] = React.useState(false);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,8 @@
         "react-native-screens": "^3.35.0",
         "react-native-snap-carousel": "^3.9.1",
         "react-native-svg": "^15.8.0",
-        "react-native-tab-view": "^3.5.2"
+        "react-native-tab-view": "^3.5.2",
+        "zustand": "^5.0.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -19634,6 +19635,35 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.1.tgz",
+      "integrity": "sha512-pRET7Lao2z+n5R/HduXMio35TncTlSW68WsYBq2Lg1ASspsNGjpwLAsij3RpouyV6+kHMwwwzP0bZPD70/Jx/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "react-native-screens": "^3.35.0",
     "react-native-snap-carousel": "^3.9.1",
     "react-native-svg": "^15.8.0",
-    "react-native-tab-view": "^3.5.2"
+    "react-native-tab-view": "^3.5.2",
+    "zustand": "^5.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/components/comment/ItemPost.tsx
+++ b/src/components/comment/ItemPost.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import {
   FlatList,
   View,
@@ -14,6 +14,7 @@ import {useNavigation} from '@react-navigation/native';
 import {PostIcon} from '@/assets/icons/dashboard/PostIcon';
 import Colors from '@/assets/colors/Colors';
 import {typography} from '../../styles/typography';
+import {usePostStore} from '../../store/usePostStore';
 
 const {subhead03, body01, caption} = typography;
 
@@ -66,6 +67,8 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
     }
   };
 
+  const imgUrls = usePostStore(state => state.imgUrls); // Zustand에서 모든 imgUrls 가져오기
+
   return (
     <FlatList
       data={postList}
@@ -79,6 +82,10 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
             ? {backgroundColor: '#FFEAE8', textColor: '#FF7163'}
             : {backgroundColor: '#FFE9DC', textColor: '#FF853E'};
 
+        // Zustand에서 현재 item.id에 해당하는 imgUrls 가져오기
+        const itemImgUrls = imgUrls[parseInt(item.id)] || []; // imgUrls가 없으면 빈 배열
+        const thumbnail = itemImgUrls.length > 0 ? itemImgUrls[0] : null; // 첫 번째 이미지
+
         return (
           <>
             <TouchableOpacity
@@ -86,7 +93,7 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
               onPress={() =>
                 navigation.navigate('PostPage', {postId: item.id})
               }>
-               {item.category !== '카테고리 미선택' && (
+              {item.category !== '카테고리 미선택' && (
                 <View
                   style={[
                     styles.containerCategory,
@@ -96,7 +103,7 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
                     {item.category}
                   </Text>
                 </View>
-                )}
+              )}
               <View style={styles.containerRow}>
                 <View style={{flex: 1}}>
                   <Text
@@ -136,8 +143,8 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
                     </View>
                   </View>
                 </View>
-                {item.thumbnail && (
-                  <Image style={styles.image} source={{uri: item.thumbnail}} />
+                {thumbnail && (
+                  <Image style={styles.image} source={{uri: thumbnail}} />
                 )}
               </View>
             </TouchableOpacity>

--- a/src/components/comment/ItemPost.tsx
+++ b/src/components/comment/ItemPost.tsx
@@ -91,7 +91,10 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
             <TouchableOpacity
               style={styles.container}
               onPress={() =>
-                navigation.navigate('PostPage', {postId: item.id})
+                navigation.navigate('PostPage', {
+                  postId: item.id,
+                  images: itemImgUrls,
+                })
               }>
               {item.category !== '카테고리 미선택' && (
                 <View

--- a/src/pages/dashboard/post/PostPage.tsx
+++ b/src/pages/dashboard/post/PostPage.tsx
@@ -1,3 +1,313 @@
+// import React, {useEffect, useState, useRef} from 'react';
+// import {
+//   SafeAreaView,
+//   ScrollView,
+//   View,
+//   Text,
+//   FlatList,
+//   Image,
+//   TouchableOpacity,
+//   KeyboardAvoidingView,
+//   Platform,
+//   TextInput,
+// } from 'react-native';
+// import {SvgXml} from 'react-native-svg';
+// import {useNavigation} from '@react-navigation/native';
+// import {RouteProp} from '@react-navigation/native';
+// import {RootStackParamList} from '../../../../types';
+
+// import Colors from '@/assets/colors/Colors';
+// import PostStyles from '@/pages/dashboard/post/PostStyles';
+// import {PostIcon} from '@/assets/icons/dashboard/PostIcon';
+// import {getPost} from '@/api/post.api';
+// import {getComments, createComment} from '@/api/comment.api';
+// import {timeAgo} from '@/util/timeAgo';
+
+// import ModalModifyDelete from '@/components/modifyDeleteModal/ModalModifyDelete';
+// import ItemComment from '@/components/comment/ItemComment';
+
+// type PostPageRouteProp = RouteProp<RootStackParamList, 'PostPage'>;
+
+// interface PostPageProps {
+//   route: PostPageRouteProp;
+// }
+
+// type ModalPosition = {
+//   x: number;
+//   y: number;
+//   width: number;
+//   height: number;
+// };
+
+// const PostPage: React.FC<PostPageProps> = ({route}) => {
+//   const {postId} = route.params;
+//   const navigation = useNavigation();
+//   const iconRef = useRef<View>(null);
+//   const [postData, setPostData] = useState<{
+//     category?: string;
+//     title?: string;
+//     content?: string;
+//     created_at?: string;
+//     num_of_comment?: number;
+//     num_of_like?: number;
+//   }>({});
+//   const [commentData, setCommentData] = useState<
+//     {
+//       id: number;
+//       is_my_comment: boolean;
+//       is_post_owner: boolean;
+//       created_at: string;
+//       modified_at: string;
+//       content: string;
+//       post_id: number;
+//     }[]
+//   >([]);
+//   const [modalVisible, setModalVisible] = useState(false);
+//   const [modalPosition, setModalPosition] = useState<ModalPosition | null>(
+//     null,
+//   );
+//   const [valueComment, onChangeComment] = useState('');
+
+//   const categoryMapping: Record<
+//     string,
+//     {label: string; color: string; boxColor: string}
+//   > = {
+//     OPERA_GLASS_RENTAL: {
+//       label: '오페라 글래스',
+//       color: '#FFB200',
+//       boxColor: Colors.sub_01,
+//     },
+//     MUSICAL_TERM: {label: '뮤지컬 용어', color: '#FF7163', boxColor: '#FFEAE8'},
+//     EVENT: {label: '이벤트', color: '#FF853E', boxColor: '#FFE9DC'},
+//   };
+
+//   const getMappedCategory = (category: string | undefined) => {
+//     if (!category) return null;
+//     return categoryMapping[category];
+//   };
+
+//   const category = getMappedCategory(postData.category);
+
+//   const handleGoBack = () => {
+//     navigation.goBack();
+//   };
+
+//   const fetchGetPost = async () => {
+//     try {
+//       const response = await getPost(postId);
+//       setPostData(response.data.data);
+//     } catch (error) {
+//       console.error('게시글 조회 오류:', error);
+//     }
+//   };
+
+//   useEffect(() => {
+//     fetchGetPost();
+//   }, []);
+
+//   const fetchGetComments = async () => {
+//     try {
+//       const response = await getComments(postId);
+//       setCommentData(response.data.data);
+//     } catch (error) {
+//       console.error('댓글 조회 오류:', error);
+//     }
+//   };
+
+//   useEffect(() => {
+//     fetchGetComments();
+//   }, [commentData]);
+
+//   const fetchCreateComment = async () => {
+//     try {
+//       if (valueComment.trim() === '') {
+//         return;
+//       }
+//       await createComment(postId, {content: valueComment, parent_id: null});
+//       onChangeComment('');
+//     } catch (error) {
+//       console.error('댓글 생성 오류:', error);
+//     }
+//   };
+
+//   const handleIconPress = () => {
+//     setModalVisible(true);
+//     if (iconRef.current) {
+//       iconRef.current.measureInWindow((x, y, width, height) => {
+//         setModalPosition({x, y, width, height});
+//       });
+//     }
+//   };
+
+//   const images = [
+//     {
+//       id: '1',
+//       image: require('@/assets/images/home/Musical4.jpeg'),
+//     },
+//     {
+//       id: '2',
+//       image: require('@/assets/images/home/Musical5.jpeg'),
+//     },
+//     {
+//       id: '3',
+//       image: require('@/assets/images/home/Musical6.jpeg'),
+//     },
+//     {
+//       id: '4',
+//       image: require('@/assets/images/home/Musical6.jpeg'),
+//     },
+//     {
+//       id: '5',
+//       image: require('@/assets/images/home/Musical6.jpeg'),
+//     },
+//   ];
+
+//   return (
+//     <>
+//       <SafeAreaView style={PostStyles.container}>
+//         <ScrollView>
+//           <View style={PostStyles.containerHeader}>
+//             <TouchableOpacity onPress={() => handleGoBack()}>
+//               <SvgXml xml={PostIcon.arrowLeft} />
+//             </TouchableOpacity>
+//             <View style={PostStyles.containerRow}>
+//               <TouchableOpacity>
+//                 <SvgXml style={{marginRight: 11}} xml={PostIcon.upload} />
+//               </TouchableOpacity>
+//               <TouchableOpacity onPress={handleIconPress}>
+//                 <View ref={iconRef}>
+//                   <SvgXml xml={PostIcon.moreVertical} />
+//                 </View>
+//               </TouchableOpacity>
+//               {modalPosition && (
+//                 <ModalModifyDelete
+//                   modalVisible={modalVisible}
+//                   setModalVisible={setModalVisible}
+//                   position={modalPosition}
+//                   postId={postId}
+//                   commentId={null}
+//                   onNavigation={navigation}
+//                 />
+//               )}
+//             </View>
+//           </View>
+
+//           <View style={{marginHorizontal: 20}}>
+//             <View
+//               style={[
+//                 PostStyles.containerCategory,
+//                 {backgroundColor: category?.boxColor},
+//               ]}>
+//               <Text style={[PostStyles.textCategory, {color: category?.color}]}>
+//                 {category?.label}
+//               </Text>
+//             </View>
+//             <Text style={PostStyles.textTitle}>{postData.title}</Text>
+//             <Text style={PostStyles.textContent}>{postData.content}</Text>
+//           </View>
+
+//           <FlatList
+//             contentContainerStyle={{marginHorizontal: 20}}
+//             data={images}
+//             renderItem={({item}) => (
+//               <Image style={PostStyles.images} source={item.image} />
+//             )}
+//             keyExtractor={(item, index) => index.toString()}
+//             horizontal={true}
+//             nestedScrollEnabled
+//           />
+
+//           <View style={{marginHorizontal: 20}}>
+//             <View style={PostStyles.line} />
+//           </View>
+
+//           <TouchableOpacity style={PostStyles.containerHashtag}>
+//             <Text style={PostStyles.textHashtag}>
+//               #벤자민버튼 #MD #드레스리허설
+//             </Text>
+//           </TouchableOpacity>
+
+//           <View style={PostStyles.containerCommentLikeItems}>
+//             <View style={[PostStyles.containerCommentLike, {marginRight: 10}]}>
+//               <SvgXml xml={PostIcon.comment} />
+//               <Text style={PostStyles.textCommentLike}>
+//                 {postData.num_of_like}
+//               </Text>
+//             </View>
+//             <View style={PostStyles.containerCommentLike}>
+//               <SvgXml xml={PostIcon.like} />
+//               <Text style={PostStyles.textCommentLike}>
+//                 {postData.num_of_comment}
+//               </Text>
+//             </View>
+//           </View>
+
+//           <View style={PostStyles.containerWriter}>
+//             <View style={PostStyles.containerRow}>
+//               <>
+//                 <SvgXml xml={PostIcon.writerBackground} />
+//                 <Image
+//                   style={PostStyles.imageWriter}
+//                   source={require('@/assets/logo/logo4.png')}
+//                 />
+//               </>
+//               <View style={PostStyles.containerWriterText}>
+//                 <View style={PostStyles.containerRow}>
+//                   <Text style={PostStyles.textWriter}>뮤사랑</Text>
+//                   <SvgXml xml={PostIcon.Badge} />
+//                 </View>
+//                 <Text style={PostStyles.textDate}>
+//                   {timeAgo(postData.created_at)}
+//                 </Text>
+//               </View>
+//             </View>
+//             <View style={PostStyles.containerWriterButton}>
+//               <Text style={PostStyles.textWriterButton}>작성자</Text>
+//             </View>
+//           </View>
+
+//           <View style={PostStyles.containerCommentTitle}>
+//             <Text style={PostStyles.textCommentTitle}>
+//               댓글 {postData.num_of_comment}
+//             </Text>
+//             <View style={PostStyles.containerRow}>
+//               <TouchableOpacity>
+//                 <Text
+//                   style={[PostStyles.textLatestRecommended, {marginRight: 12}]}>
+//                   최신순
+//                 </Text>
+//               </TouchableOpacity>
+//               <TouchableOpacity>
+//                 <Text style={PostStyles.textLatestRecommended}>추천순</Text>
+//               </TouchableOpacity>
+//             </View>
+//           </View>
+
+//           <ItemComment commentList={commentData} />
+//         </ScrollView>
+//       </SafeAreaView>
+//       <View style={PostStyles.white} />
+//       <KeyboardAvoidingView
+//         style={PostStyles.containerCommentInput}
+//         behavior={Platform.OS === 'ios' ? 'padding' : 'height'}>
+//         <SvgXml xml={PostIcon.commentImage} />
+//         <View style={PostStyles.containerCommentTextInput}>
+//           <TextInput
+//             style={PostStyles.textCommentInput}
+//             placeholder={'댓글을 입력해주세요'}
+//             onChangeText={text => onChangeComment(text)}
+//             value={valueComment}
+//           />
+//           <TouchableOpacity onPress={fetchCreateComment}>
+//             <Text style={PostStyles.textCommentSend}>등록</Text>
+//           </TouchableOpacity>
+//         </View>
+//       </KeyboardAvoidingView>
+//     </>
+//   );
+// };
+
+// export default PostPage;
 import React, {useEffect, useState, useRef} from 'react';
 import {
   SafeAreaView,
@@ -30,6 +340,7 @@ type PostPageRouteProp = RouteProp<RootStackParamList, 'PostPage'>;
 
 interface PostPageProps {
   route: PostPageRouteProp;
+  images?: string[];
 }
 
 type ModalPosition = {
@@ -40,7 +351,7 @@ type ModalPosition = {
 };
 
 const PostPage: React.FC<PostPageProps> = ({route}) => {
-  const {postId} = route.params;
+  const {postId, images: itemImgUrls} = route.params; // imgUrls 추가
   const navigation = useNavigation();
   const iconRef = useRef<View>(null);
   const [postData, setPostData] = useState<{
@@ -139,7 +450,8 @@ const PostPage: React.FC<PostPageProps> = ({route}) => {
     }
   };
 
-  const images = [
+  // 기본 이미지 리스트
+  const defaultImages = [
     {
       id: '1',
       image: require('@/assets/images/home/Musical4.jpeg'),
@@ -161,6 +473,14 @@ const PostPage: React.FC<PostPageProps> = ({route}) => {
       image: require('@/assets/images/home/Musical6.jpeg'),
     },
   ];
+
+  const imagesToRender =
+    itemImgUrls && itemImgUrls.length > 0
+      ? itemImgUrls.map((url: string, index: number) => ({
+          id: index.toString(),
+          image: {uri: url},
+        }))
+      : defaultImages;
 
   return (
     <>
@@ -206,13 +526,14 @@ const PostPage: React.FC<PostPageProps> = ({route}) => {
             <Text style={PostStyles.textContent}>{postData.content}</Text>
           </View>
 
+          {/* 이미지 렌더링 */}
           <FlatList
             contentContainerStyle={{marginHorizontal: 20}}
-            data={images}
+            data={imagesToRender} // 렌더링할 이미지 배열
             renderItem={({item}) => (
               <Image style={PostStyles.images} source={item.image} />
             )}
-            keyExtractor={(item, index) => index.toString()}
+            keyExtractor={item => item.id}
             horizontal={true}
             nestedScrollEnabled
           />

--- a/src/store/usePostStore.tsx
+++ b/src/store/usePostStore.tsx
@@ -1,0 +1,25 @@
+import {create} from 'zustand';
+
+interface PostStoreState {
+  postResponse: any; // response.data 저장
+  imgUrls: Record<number, string[]>; // id를 키로 하는 imgUrls 저장
+  currentPostId: number | null; // 현재 선택된 postId
+  setPostResponse: (data: any) => void; // response.data 업데이트
+  setImgUrls: (id: number, urls: string[]) => void; // id에 해당하는 imgUrls 저장
+  setCurrentPostId: (id: number) => void; // currentPostId 업데이트
+}
+
+export const usePostStore = create<PostStoreState>(set => ({
+  postResponse: null, // 초기 상태
+  imgUrls: {}, // id별 imgUrls 초기 상태
+  currentPostId: null, // 초기 상태: null
+  setPostResponse: data => set({postResponse: data}),
+  setImgUrls: (id, urls) =>
+    set(state => ({
+      imgUrls: {
+        ...state.imgUrls,
+        [id]: urls, // 특정 id에 해당하는 imgUrls 저장
+      },
+    })),
+  setCurrentPostId: id => set({currentPostId: id}), // currentPostId 업데이트
+}));


### PR DESCRIPTION
### 개요
- 리스트에 이미지 썸네일 추가

### 결과 화면 
<img width="534" alt="image" src="https://github.com/user-attachments/assets/e78f94e1-8990-4f76-9605-2486f7786837">

### 참고 사항
![image](https://github.com/user-attachments/assets/98c07326-ef65-4086-801b-9fb0e3050819)
- 백엔드 수정 요청 필요:  게시글 작성으로 imgUrl까지 등록하고 나서, 해당 id로 게시글 상세 조회했을 때 hashtags, post_images가 빈 배열로 나옴. 등록하면, 해당 게시글에 추가하는 로직 있어야할듯