### PR TITLE
코드리뷰용 임시저장목록

### DIFF
--- a/src/components/bottomTab/WriteBottomTab.tsx
+++ b/src/components/bottomTab/WriteBottomTab.tsx
@@ -111,7 +111,16 @@ const WriteBottomTab: React.FC<WriteBottomTabProps> = ({
         );
 
         if (savedPosts.length >= 10) {
+<<<<<<< HEAD
           openModal(selectedTitle, selectedSubTitle, topButton, bottomButton);
+=======
+          openModal(
+            '10개를 초과해' + '\n' + '마지막 글을 삭제합니다.',
+            '삭제하시겠어요?',
+            '삭제하기',
+            '취소하기',
+          );
+>>>>>>> dd613af (feat: 임시저장 글 개수 10개 초과 모달 수정)
           return;
         }
 

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -19,7 +19,6 @@ import IconLike from '@/assets/icons/home/IconLike';
 import IconComment from '@/assets/icons/home/IconComment';
 import IconDate from '@/assets/icons/home/IconDate';
 import IconActor from '@/assets/icons/home/IconActor';
-import {HomeIcon} from '@/assets/icons/dashboard/HomeIcon';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 
 type HomePageProps = {};

--- a/src/pages/write/save/SavePage.tsx
+++ b/src/pages/write/save/SavePage.tsx
@@ -31,7 +31,10 @@ type RootStackParamList = {
 };
 
 const SavePage: React.FC = () => {
+<<<<<<< HEAD
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+=======
+>>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
   const [isLoading, setIsLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedTitle, setSelectedTitle] = useState('');
@@ -42,6 +45,7 @@ const SavePage: React.FC = () => {
   const [count, setCount] = useState(0);
   const [savedPosts, setSavedPosts] = useState<any[]>([]);
 
+<<<<<<< HEAD
   // const fetchSavedPosts = async () => {
   //   try {
   //     const storedData = await AsyncStorage.getItem('temporaryPosts');
@@ -127,6 +131,45 @@ const SavePage: React.FC = () => {
     }
   };
 
+=======
+  const fetchSavedPosts = async () => {
+    try {
+      const storedData = await AsyncStorage.getItem('temporaryPosts');
+      console.log('스토리지에 저장된 임시 저장 글: ', storedData);
+      const parsedData = JSON.parse(storedData || '[]');
+
+      const fetchedPosts = await Promise.all(
+        parsedData.map(async (post: {post_id: number}) => {
+          const response = await getPost(post.post_id);
+          // console.log('getPost 호출 결과값: ', response.data.data);
+          return response.data.data;
+        }),
+      );
+
+      setSavedPosts(fetchedPosts);
+      setCount(fetchedPosts.length);
+      // console.log('Fetched Posts:', fetchedPosts);
+
+      if (parsedData.length === 0) {
+        setCount(0);
+        setSavedPosts([]);
+        return;
+      }
+    } catch (error) {
+      if (count === 0) {
+        setSavedPosts([]);
+      } else {
+        console.error('Error fetching saved posts:', error);
+        Alert.alert(
+          '임시 저장 목록을 불러오는 도중 문제가 발생했습니다. 다시 시도해주세요.',
+        );
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+>>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
   // 삭제 시 UI에 반영하기 위한 함수
   useEffect(() => {
     fetchSavedPosts();
@@ -147,6 +190,7 @@ const SavePage: React.FC = () => {
     setSelectedPostId(postId);
   };
 
+<<<<<<< HEAD
   console.log('storageData: ', savedPosts);
   // console.log('저장된 임시 저장글 개수: ', count);
 
@@ -164,6 +208,16 @@ const SavePage: React.FC = () => {
       <View style={{marginTop: 20}}>
         <ActivityIndicator size="large" />
       </View>
+=======
+  // console.log('storageData: ', savedPosts);
+  // console.log('저장된 임시 저장글 개수: ', count);
+
+  if (isLoading) {
+    return (
+      <>
+        <ActivityIndicator size="large" />
+      </>
+>>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
     );
   }
 
@@ -186,11 +240,15 @@ const SavePage: React.FC = () => {
                 <View key={item.post_id} style={SaveStyles.list_container}>
                   <View style={SaveStyles.list}>
                     <View style={SaveStyles.sub_container}>
+<<<<<<< HEAD
                       <TouchableOpacity
                         onPress={() => handleClick(item.post_id)}>
                         <Text style={SaveStyles.list_title}>{item.title}</Text>
                       </TouchableOpacity>
 
+=======
+                      <Text style={SaveStyles.list_title}>{item.title}</Text>
+>>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
                       <TouchableOpacity
                         onPress={() =>
                           openModal(
@@ -211,7 +269,11 @@ const SavePage: React.FC = () => {
                         {timeAgo(item.modified_at)}
                       </Text>
                       <Text style={SaveStyles.list_expire_date}>
+<<<<<<< HEAD
                         {deleteTimeAgo(item.modified_at).message}
+=======
+                        {item.expireDate}일 뒤 자동 삭제
+>>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
                       </Text>
                     </View>
                   </View>
@@ -219,11 +281,14 @@ const SavePage: React.FC = () => {
                 </View>
               ))
             )}
+<<<<<<< HEAD
           </View>
           <View style={{marginTop: 60}}>
             <Text style={SaveStyles.notice}>
               2주가 지난 임시저장글은 자동으로 삭제됩니다.
             </Text>
+=======
+>>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
           </View>
         </ScrollView>
       </SafeAreaView>

--- a/src/pages/write/save/SavePage.tsx
+++ b/src/pages/write/save/SavePage.tsx
@@ -32,9 +32,13 @@ type RootStackParamList = {
 
 const SavePage: React.FC = () => {
 <<<<<<< HEAD
+<<<<<<< HEAD
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 =======
 >>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
+=======
+  const navigation = useNavigation<NavigationProp<RootStackParamList>>();
+>>>>>>> e8335b8 (feat: 임시 저장 목록 데이터를 작성 페이지로 불러오기)
   const [isLoading, setIsLoading] = useState(true);
   const [modalVisible, setModalVisible] = useState(false);
   const [selectedTitle, setSelectedTitle] = useState('');
@@ -203,6 +207,7 @@ const SavePage: React.FC = () => {
     }
   };
 
+<<<<<<< HEAD
   if (isLoading) {
     return (
       <View style={{marginTop: 20}}>
@@ -212,12 +217,18 @@ const SavePage: React.FC = () => {
   // console.log('storageData: ', savedPosts);
   // console.log('저장된 임시 저장글 개수: ', count);
 
+=======
+>>>>>>> e8335b8 (feat: 임시 저장 목록 데이터를 작성 페이지로 불러오기)
   if (isLoading) {
     return (
-      <>
+      <View style={{marginTop: 20}}>
         <ActivityIndicator size="large" />
+<<<<<<< HEAD
       </>
 >>>>>>> 5a75c98 (feat: 임시저장 목록 로딩 화면 추가 및 데이터가 없을 때 예외 처리)
+=======
+      </View>
+>>>>>>> e8335b8 (feat: 임시 저장 목록 데이터를 작성 페이지로 불러오기)
     );
   }
 
@@ -241,6 +252,9 @@ const SavePage: React.FC = () => {
                   <View style={SaveStyles.list}>
                     <View style={SaveStyles.sub_container}>
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> e8335b8 (feat: 임시 저장 목록 데이터를 작성 페이지로 불러오기)
                       <TouchableOpacity
                         onPress={() => handleClick(item.post_id)}>
                         <Text style={SaveStyles.list_title}>{item.title}</Text>


### PR DESCRIPTION
### 개요
임시 저장 목록 케이스 수정

### 수정
1. 임시 저장 목록 유무에 따른 모달 https://encore-team-fe.atlassian.net/browse/KAN-23
2. 만료 시간 UI 수정 https://encore-team-fe.atlassian.net/browse/KAN-37
3. 임시 저장 글 10개 초과 https://encore-team-fe.atlassian.net/browse/KAN-22
4. 임시 저장 글 삭제 https://encore-team-fe.atlassian.net/browse/KAN-21
5. 임시 저장 목록 데이터를 글 작성 페이지로 그대로 가져오기 https://encore-team-fe.atlassian.net/browse/KAN-38


### 결과 화면
#### 1. 임시 저장 목록 유무에 따른 모달
<img width="400" alt="스크린샷 2024-12-01 오후 7 04 56" src="https://github.com/user-attachments/assets/501381cf-dd53-423f-8fd3-99bc3db7612a">

#### 2. 만료 시간 UI 수정
<img width="400" alt="스크린샷 2024-12-01 오후 7 05 01" src="https://github.com/user-attachments/assets/8cd64e1c-b214-4bb0-a822-d111f4645803">

#### 3. 10개 초과 모달
<img width="400" alt="스크린샷 2024-12-01 오후 7 05 35" src="https://github.com/user-attachments/assets/a6f2adb1-7da4-48b8-b58c-6764a4c4bb7f">
<img width="400" alt="스크린샷 2024-12-01 오후 7 05 41" src="https://github.com/user-attachments/assets/526ae551-7ad2-4124-8387-9b64ffe4110a">

#### 4. 임시저장 글 삭제 모달
<img width="400" alt="스크린샷 2024-12-01 오후 7 05 52" src="https://github.com/user-attachments/assets/e49c212e-3919-4471-8a94-c0704e766112">
<img width="400" alt="스크린샷 2024-12-01 오후 7 05 57" src="https://github.com/user-attachments/assets/9ab3af34-8570-4113-b12b-0d3fca27a8ef">

### 참고 사항
- 임시 저장 시 중복 처리를 구현하지 못한 상태
- AsyncStorage와 관련되어 manifest.json이 누락되거나 손상되었다는 오류가 가끔 발생하게 됨 
- 이를 해결하고자... 
1. 디렉토리 확인 및 생성: AsyncStorage가 데이터를 저장할 경로가 항상 준비되도록 보장합니다.
2. manifest.json 초기화: 메타데이터 관리에 필요한 manifest.json 파일이 반드시 존재하도록 보장합니다.