### PR TITLE
Design/homepage: 홈페이지 UI 수정

### DIFF
--- a/src/pages/dashboard/DashboardPage.tsx
+++ b/src/pages/dashboard/DashboardPage.tsx
@@ -23,27 +23,23 @@ type RootStackParamList = {
 const DashboardPage: React.FC = () => {
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
-  const renderHeader = () => (
-    <View style={DashboardStyles.containerHeader}>
-      <View style={DashboardStyles.containerIcons}>
-        <Text style={DashboardStyles.textTitle}>게시판</Text>
-        <View style={DashboardStyles.containerRow}>
-          <TouchableOpacity
-            onPress={() => navigation.navigate('DashboardSearchDefaultPage')}>
-            <IconSearch style={{marginRight: 20}} />
-          </TouchableOpacity>
-          <IconNotification />
-        </View>
-      </View>
-    </View>
-  );
-
   return (
     <SafeAreaView style={DashboardStyles.container}>
+      <View style={DashboardStyles.containerHeader}>
+        <View style={DashboardStyles.containerIcons}>
+          <Text style={DashboardStyles.textTitle}>게시판</Text>
+          <View style={DashboardStyles.containerRow}>
+            <TouchableOpacity
+              onPress={() => navigation.navigate('DashboardSearchDefaultPage')}>
+              <IconSearch style={{marginRight: 20}} />
+            </TouchableOpacity>
+            <IconNotification />
+          </View>
+        </View>
+      </View>
       <FlatList
         keyExtractor={item => String(item.id)}
         data={[]}
-        ListHeaderComponent={renderHeader}
         renderItem={null}
         ListFooterComponent={<DashboardTabs />}
       />

--- a/src/pages/dashboard/search/SearchStyles.tsx
+++ b/src/pages/dashboard/search/SearchStyles.tsx
@@ -78,7 +78,7 @@ const SearchStyles = StyleSheet.create({
     color: Colors.wireframe_400,
   },
   recentSearchItem: {
-    paddingVertical: 10,
+    paddingVertical: 12,
     borderBottomWidth: 1,
     borderBottomColor: '#ddd',
     flexDirection: 'row',
@@ -86,7 +86,7 @@ const SearchStyles = StyleSheet.create({
     justifyContent: 'space-between',
   },
   recentSearchText: {
-    fontSize: 14,
+    fontSize: 16,
     color: '#333',
   },
   noHistoryContainer: {

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -328,18 +328,19 @@ const HomePage: React.FC<HomePageProps> = () => {
 
   return (
     <SafeAreaView style={HomeStyles.container}>
+      <View style={HomeStyles.containerIcons}>
+        <SvgXml xml={HomeIcon.iconTitle} />
+        <View style={HomeStyles.containerRow}>
+          <TouchableOpacity
+            onPress={() => navigation.navigate('HomeSearchDefaultPage')}>
+            <IconSearch style={{marginRight: 20}} />
+          </TouchableOpacity>
+          <IconNotification />
+        </View>
+      </View>
+
       <ScrollView>
         <View style={HomeStyles.containerHeader}>
-          <View style={HomeStyles.containerIcons}>
-            <SvgXml xml={HomeIcon.iconTitle} />
-            <View style={HomeStyles.containerRow}>
-              <TouchableOpacity
-                onPress={() => navigation.navigate('HomeSearchDefaultPage')}>
-                <IconSearch style={{marginRight: 20}} />
-              </TouchableOpacity>
-              <IconNotification />
-            </View>
-          </View>
           <FlatList
             ref={bannerRef}
             data={circularCarouselTicketList}

--- a/src/pages/home/HomePage.tsx
+++ b/src/pages/home/HomePage.tsx
@@ -425,7 +425,10 @@ const HomePage: React.FC<HomePageProps> = () => {
                 </View>
                 <View style={[HomeStyles.containerRow, {marginBottom: 4}]}>
                   <SvgXml xml={HomeIcon.place} />
-                  <Text style={HomeStyles.textTicketDateActor}>
+                  <Text
+                    style={HomeStyles.textTicketDateActor}
+                    numberOfLines={1}
+                    ellipsizeMode="tail">
                     {ticketList?.location} {ticketList?.seat}
                   </Text>
                 </View>
@@ -478,7 +481,7 @@ const HomePage: React.FC<HomePageProps> = () => {
           <Text style={HomeStyles.textWriteReview}>전체보기 {'>'}</Text>
         </View>
         <View style={{alignItems: 'center'}}>
-          {popularPremiumReviews.map((review, index) => (
+          {popularPremiumReviews.slice(0, 3).map((review, index) => (
             <View
               key={review.review_id}
               style={HomeStyles.containerPremiumReviews}>

--- a/src/pages/home/HomeStyles.tsx
+++ b/src/pages/home/HomeStyles.tsx
@@ -117,7 +117,9 @@ const HomeStyles = StyleSheet.create({
   textTicketDateActor: {
     ...caption,
     color: Colors.gray_12,
+    width: 200,
     marginLeft: 6,
+    overflow: 'hidden',
   },
   ticketLine: {
     position: 'absolute',

--- a/src/pages/home/HomeStyles.tsx
+++ b/src/pages/home/HomeStyles.tsx
@@ -11,7 +11,7 @@ const HomeStyles = StyleSheet.create({
     backgroundColor: Colors.gray_01,
   },
   containerHeader: {
-    height: 280,
+    height: 210,
     overflow: 'hidden',
   },
   containerIcons: {

--- a/src/pages/home/search/CombinedSearchScreen.tsx
+++ b/src/pages/home/search/CombinedSearchScreen.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Text} from 'react-native';
+import {View} from 'react-native';
 import MusicalSearchScreen from './MusicalSearchScreen';
 import DashboardSearchScreen from '@/pages/dashboard/search/DashboardSearchScreen';
 import PremiumSearchScreen from './PremiumSearchScreen';
@@ -16,6 +16,7 @@ const CombinedSearchScreen: React.FC<SearchScreenProps> = ({
   return (
     <>
       <MusicalSearchScreen postData={postData} text={text} />
+      <View style={{marginTop: 32}} />
       <DashboardSearchScreen postData={postData} />
       <PremiumSearchScreen postData={postData} text={text} />
     </>

--- a/src/pages/home/search/MusicalSearchScreen.tsx
+++ b/src/pages/home/search/MusicalSearchScreen.tsx
@@ -91,7 +91,6 @@ const MusicalSearchScreen: React.FC<SearchScreenProps> = ({postData, text}) => {
           }
         />
       </View>
-      <View style={HomeStyles.line2} />
     </View>
   );
 };

--- a/src/pages/home/search/PremiumSearchScreen.tsx
+++ b/src/pages/home/search/PremiumSearchScreen.tsx
@@ -75,7 +75,6 @@ const PremiumSearchScreen: React.FC<SearchScreenProps> = ({postData, text}) => {
           }
         />
       </View>
-      <View style={HomeStyles.line2} />
     </View>
   );
 };

--- a/src/pages/myPage/MyPage.tsx
+++ b/src/pages/myPage/MyPage.tsx
@@ -58,8 +58,8 @@ export default function MyPage() {
     console.log('Updated userData:', userData);
   }, [userData]);
 
-  const renderHeader = () => (
-    <>
+  return (
+    <SafeAreaView style={MyPageStyles.container}>
       <View style={MyPageStyles.containerHeader}>
         <View style={MyPageStyles.containerIcons}>
           <Text style={MyPageStyles.textTitle}>마이페이지</Text>
@@ -77,17 +77,11 @@ export default function MyPage() {
           </View>
         </View>
       </View>
-    </>
-  );
-
-  return (
-    <SafeAreaView style={MyPageStyles.container}>
       <FlatList
         keyExtractor={item => item.id.toString()}
         data={[]}
         ListHeaderComponent={
           <>
-            {renderHeader()}
             <View style={MyPageStyles.containerHeader}>
               <View style={MyPageStyles.rectContainer}>
                 <SvgXml xml={MyPageIcon.rectangle1} />

--- a/src/pages/premium/PremiumPage.tsx
+++ b/src/pages/premium/PremiumPage.tsx
@@ -135,6 +135,19 @@ export default function PremiumPage() {
 
   return (
     <SafeAreaView style={PremiumStyles.container}>
+      <View style={PremiumStyles.containerHeader}>
+        <View style={PremiumStyles.containerIcons}>
+          <Text style={PremiumStyles.textTitle}>프리미엄</Text>
+          <View style={PremiumStyles.containerRow}>
+            <TouchableOpacity
+              onPress={() => navigation.navigate('PremiumSearchDefaultPage')}
+              onLayout={handleLayout}>
+              <IconSearch style={{marginRight: 20}} />
+            </TouchableOpacity>
+            <IconNotification />
+          </View>
+        </View>
+      </View>
       <FlatList
         data={data}
         keyExtractor={(item, index) => item.id || index.toString()}
@@ -147,20 +160,6 @@ export default function PremiumPage() {
         ListHeaderComponent={
           <>
             <View style={PremiumStyles.containerHeader}>
-              <View style={PremiumStyles.containerIcons}>
-                <Text style={PremiumStyles.textTitle}>프리미엄</Text>
-                <View style={PremiumStyles.containerRow}>
-                  <TouchableOpacity
-                    onPress={() =>
-                      navigation.navigate('PremiumSearchDefaultPage')
-                    }
-                    onLayout={handleLayout}>
-                    <IconSearch style={{marginRight: 20}} />
-                  </TouchableOpacity>
-                  <IconNotification />
-                </View>
-              </View>
-
               {reviewModalVisible && (
                 <ToolTipModal
                   visible={reviewModalVisible}

--- a/src/pages/ticketbook/TicketBookPage.tsx
+++ b/src/pages/ticketbook/TicketBookPage.tsx
@@ -163,18 +163,6 @@ export default function TicketBookPage() {
 
   const renderHeader = () => (
     <>
-      <View style={TicketBookStyles.containerHeader}>
-        <View style={TicketBookStyles.containerIcons}>
-          <Text style={TicketBookStyles.textTitle}>티켓북</Text>
-          <View style={TicketBookStyles.containerRow}>
-            <TouchableOpacity>
-              <IconSearch style={{marginRight: 20}} />
-            </TouchableOpacity>
-            <IconNotification />
-          </View>
-        </View>
-      </View>
-
       <TouchableOpacity
         style={{
           flexDirection: 'row',
@@ -236,6 +224,17 @@ export default function TicketBookPage() {
 
   return (
     <SafeAreaView style={TicketBookStyles.container}>
+      <View style={TicketBookStyles.containerHeader}>
+        <View style={TicketBookStyles.containerIcons}>
+          <Text style={TicketBookStyles.textTitle}>티켓북</Text>
+          <View style={TicketBookStyles.containerRow}>
+            <TouchableOpacity>
+              <IconSearch style={{marginRight: 20}} />
+            </TouchableOpacity>
+            <IconNotification />
+          </View>
+        </View>
+      </View>
       <FlatList
         data={[]}
         ListHeaderComponent={renderHeader}


### PR DESCRIPTION
## #️⃣연관된 이슈

- ex) #이슈번호, #이슈번호

## 📝작업 내용
- 상단바 고정
- 두줄 이상 케이스 텍스트 처리
- 4,5순위 제거
- 홈 검색 페이지 라인 제거
- 홈 검색 페이지 검색 기록 패딩값, 글씨 크기 수정

## 결과 화면
<img width="510" alt="스크린샷 2025-02-08 오후 6 39 40" src="https://github.com/user-attachments/assets/65f73ba9-77f4-488b-b461-9e394aaffb92" />

## 💬참고 사항
>
