### PR TITLE
feat: 수신 설정 페이지 UI 구현 

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -32,6 +32,7 @@ import {AddTicketProvider} from './src/state/AddTicketContext';
 import {OnboardingProvider} from './src/state/OnboardingContext';
 import MusicalDetailScreen from './src/screens/home/musical/MusicalDetailScreen';
 import ModifyProfileImg from './src/screens/myScreen/ModifyProfileImg';
+import NotificationSettings from './src/screens/myScreen/NotificationSettings';
 import {createPost, putPost} from './src/api/post.api';
 import {ensureAsyncStorageDir} from './src/util/ensureAsyncStorageDir';
 
@@ -476,6 +477,22 @@ export default function App() {
                     backgroundColor: '#FBFBFB',
                   },
                   title: '프로필 수정',
+                  headerTitleStyle: {...AppStyles.title},
+                  headerLeft: () => (
+                    <CustomBackButton navigation={navigation} />
+                  ),
+                })}
+              />
+            {/* 마이페이지: 수신 설정 페이지 */}
+            <Stack.Screen
+                name="NotificationSettings" // @@
+                component={NotificationSettings}
+                options={({navigation}) => ({
+                  headerStyle: {
+                    height: 123,
+                    backgroundColor: '#FBFBFB',
+                  },
+                  title: '수신 설정',
                   headerTitleStyle: {...AppStyles.title},
                   headerLeft: () => (
                     <CustomBackButton navigation={navigation} />

--- a/App.tsx
+++ b/App.tsx
@@ -33,6 +33,7 @@ import {OnboardingProvider} from './src/state/OnboardingContext';
 import MusicalDetailScreen from './src/screens/home/musical/MusicalDetailScreen';
 import ModifyProfileImg from './src/screens/myScreen/ModifyProfileImg';
 import NotificationSettings from './src/screens/myScreen/NotificationSettings';
+import MarketingDetails from './src/screens/myScreen/MarketingDetails';
 import {createPost, putPost} from './src/api/post.api';
 import {ensureAsyncStorageDir} from './src/util/ensureAsyncStorageDir';
 
@@ -485,7 +486,7 @@ export default function App() {
               />
             {/* 마이페이지: 수신 설정 페이지 */}
             <Stack.Screen
-                name="NotificationSettings" // @@
+                name="NotificationSettings"
                 component={NotificationSettings}
                 options={({navigation}) => ({
                   headerStyle: {
@@ -493,6 +494,22 @@ export default function App() {
                     backgroundColor: '#FBFBFB',
                   },
                   title: '수신 설정',
+                  headerTitleStyle: {...AppStyles.title},
+                  headerLeft: () => (
+                    <CustomBackButton navigation={navigation} />
+                  ),
+                })}
+              />
+              {/* 마이페이지: 마케팅 정보 수신 페이지 */}
+              <Stack.Screen
+                name="MarketingDetails" 
+                component={MarketingDetails}
+                options={({navigation}) => ({
+                  headerStyle: {
+                    height: 123,
+                    backgroundColor: '#FBFBFB',
+                  },
+                  title: '마케팅 정보 수신',
                   headerTitleStyle: {...AppStyles.title},
                   headerLeft: () => (
                     <CustomBackButton navigation={navigation} />

--- a/src/screens/myScreen/MarketingDetails.tsx
+++ b/src/screens/myScreen/MarketingDetails.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import { SafeAreaView, ScrollView, Text, StyleSheet } from "react-native";
+
+const MarketingDetails = () => {
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.scrollContainer}>
+        {/* 안내 문구 */}
+        <Text style={styles.infoText}>
+          앙코르는 개인정보 보호법 제22조 제4항과 제39조의 3에 따라 {"\n"} 
+          사용자의 광고성 정보 수신과 이에 따른 개인정보 처리에 대한 {"\n"} 
+          동의를 받고 있습니다. 약관에 동의하지 않아도 앙코르의 {"\n"}
+          서비스를 이용하실 수 있으나, 이벤트 혜택 등의 제한이 있을 수 {"\n"}있습니다.
+        </Text>
+
+        {/* 개인정보 수집 항목 */}
+        <Text style={styles.sectionTitle}>개인정보 수집 항목</Text>
+        <Text style={styles.listItem}>•  이름</Text>
+        <Text style={styles.listItem}>•  휴대폰 번호</Text>
+        <Text style={styles.listItem}>•  성별</Text>
+        <Text style={styles.listItem}>•  생년월일</Text>
+
+        {/* 개인정보 수집 이용 목적 */}
+        <Text style={styles.sectionTitle}>개인정보 수집 이용 목적</Text>
+        <Text style={styles.listItem}>•  이벤트 운영 및 광고성 정보 전송</Text>
+        <Text style={styles.listItem}>•  서비스 관련 정보 전송</Text>
+
+        {/* 보유 기간 */}
+        <Text style={styles.sectionTitle}>보유 기간</Text>
+        <Text style={styles.listItem}>•  동의 철회 혹은 회원 탈퇴 시까지</Text>
+
+        {/* 동의 철회 방식 */}
+        <Text style={styles.sectionTitle}>동의 철회 방식</Text>
+        <Text style={styles.listItem}>•  알림/수신 설정 페이지에서 변경</Text>
+
+        {/* 전송 방식 */}
+        <Text style={styles.sectionTitle}>전송 방식</Text>
+        <Text style={styles.listItem}>•  전화번호 문자메시지 등</Text>
+
+        {/* 전송 내용 */}
+        <Text style={styles.sectionTitle}>전송 내용</Text>
+        <Text style={styles.listItem}>•  혜택 및 이벤트 정보, 신규 서비스 안내 등의 광고성 정보</Text>
+      </ScrollView>
+    </SafeAreaView>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  scrollContainer: {
+    paddingBottom: 30, // 스크롤 마지막 항목 여백 추가
+  },
+  infoText: {
+    fontSize: 14,       // 글자 크기
+    lineHeight: 24,     // 줄 간격
+    letterSpacing: -0.3,// 글자 간격
+    color: "#000000",
+    marginTop: 28,  
+    marginLeft: 21, 
+    marginRight: 19, 
+  },
+  sectionTitle: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#000000",
+    marginTop: 24, 
+    marginLeft: 21, 
+    marginRight: 19, 
+  },
+  listItem: {
+    fontSize: 14,
+    color: "#000000",
+    marginTop: 11, 
+    marginLeft: 21, 
+    marginRight: 19, 
+  },
+});
+
+export default MarketingDetails;

--- a/src/screens/myScreen/MarketingDetails.tsx
+++ b/src/screens/myScreen/MarketingDetails.tsx
@@ -1,12 +1,13 @@
 import React from "react";
-import { SafeAreaView, ScrollView, Text, StyleSheet } from "react-native";
+import { SafeAreaView, ScrollView, Text } from "react-native";
+import MyScreenStyles from "./MyScreenStyles"; // 수정된 스타일 가져오기
 
 const MarketingDetails = () => {
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView contentContainerStyle={styles.scrollContainer}>
+    <SafeAreaView style={MyScreenStyles.marketingDetailsContainer}>
+      <ScrollView contentContainerStyle={MyScreenStyles.marketingDetailsScrollContainer}>
         {/* 안내 문구 */}
-        <Text style={styles.infoText}>
+        <Text style={MyScreenStyles.marketingDetailsInfoText}>
           앙코르는 개인정보 보호법 제22조 제4항과 제39조의 3에 따라 {"\n"} 
           사용자의 광고성 정보 수신과 이에 따른 개인정보 처리에 대한 {"\n"} 
           동의를 받고 있습니다. 약관에 동의하지 않아도 앙코르의 {"\n"}
@@ -14,69 +15,37 @@ const MarketingDetails = () => {
         </Text>
 
         {/* 개인정보 수집 항목 */}
-        <Text style={styles.sectionTitle}>개인정보 수집 항목</Text>
-        <Text style={styles.listItem}>•  이름</Text>
-        <Text style={styles.listItem}>•  휴대폰 번호</Text>
-        <Text style={styles.listItem}>•  성별</Text>
-        <Text style={styles.listItem}>•  생년월일</Text>
+        <Text style={MyScreenStyles.marketingDetailsSectionTitle}>개인정보 수집 항목</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  이름</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  휴대폰 번호</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  성별</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  생년월일</Text>
 
         {/* 개인정보 수집 이용 목적 */}
-        <Text style={styles.sectionTitle}>개인정보 수집 이용 목적</Text>
-        <Text style={styles.listItem}>•  이벤트 운영 및 광고성 정보 전송</Text>
-        <Text style={styles.listItem}>•  서비스 관련 정보 전송</Text>
+        <Text style={MyScreenStyles.marketingDetailsSectionTitle}>개인정보 수집 이용 목적</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  이벤트 운영 및 광고성 정보 전송</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  서비스 관련 정보 전송</Text>
 
         {/* 보유 기간 */}
-        <Text style={styles.sectionTitle}>보유 기간</Text>
-        <Text style={styles.listItem}>•  동의 철회 혹은 회원 탈퇴 시까지</Text>
+        <Text style={MyScreenStyles.marketingDetailsSectionTitle}>보유 기간</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  동의 철회 혹은 회원 탈퇴 시까지</Text>
 
         {/* 동의 철회 방식 */}
-        <Text style={styles.sectionTitle}>동의 철회 방식</Text>
-        <Text style={styles.listItem}>•  알림/수신 설정 페이지에서 변경</Text>
+        <Text style={MyScreenStyles.marketingDetailsSectionTitle}>동의 철회 방식</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  알림/수신 설정 페이지에서 변경</Text>
 
         {/* 전송 방식 */}
-        <Text style={styles.sectionTitle}>전송 방식</Text>
-        <Text style={styles.listItem}>•  전화번호 문자메시지 등</Text>
+        <Text style={MyScreenStyles.marketingDetailsSectionTitle}>전송 방식</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>•  전화번호 문자메시지 등</Text>
 
         {/* 전송 내용 */}
-        <Text style={styles.sectionTitle}>전송 내용</Text>
-        <Text style={styles.listItem}>•  혜택 및 이벤트 정보, 신규 서비스 안내 등의 광고성 정보</Text>
+        <Text style={MyScreenStyles.marketingDetailsSectionTitle}>전송 내용</Text>
+        <Text style={MyScreenStyles.marketingDetailsListItem}>
+          •  혜택 및 이벤트 정보, 신규 서비스 안내 등의 광고성 정보
+        </Text>
       </ScrollView>
     </SafeAreaView>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: "#FFFFFF",
-  },
-  scrollContainer: {
-    paddingBottom: 30, // 스크롤 마지막 항목 여백 추가
-  },
-  infoText: {
-    fontSize: 14,       // 글자 크기
-    lineHeight: 24,     // 줄 간격
-    letterSpacing: -0.3,// 글자 간격
-    color: "#000000",
-    marginTop: 28,  
-    marginLeft: 21, 
-    marginRight: 19, 
-  },
-  sectionTitle: {
-    fontSize: 16,
-    fontWeight: "bold",
-    color: "#000000",
-    marginTop: 24, 
-    marginLeft: 21, 
-    marginRight: 19, 
-  },
-  listItem: {
-    fontSize: 14,
-    color: "#000000",
-    marginTop: 11, 
-    marginLeft: 21, 
-    marginRight: 19, 
-  },
-});
 
 export default MarketingDetails;

--- a/src/screens/myScreen/MyScreen.tsx
+++ b/src/screens/myScreen/MyScreen.tsx
@@ -15,7 +15,7 @@ import {useFocusEffect, useNavigation} from '@react-navigation/native';
 import {getMyInfo} from '@/api/users.api';
 
 type NavigationProp = {
-  navigate: (screen: 'ModifyProfileImg') => void;
+  navigate: (screen: 'ModifyProfileImg' | 'NotificationSettings') => void;
 };
 
 export default function MyScreen() {
@@ -177,9 +177,12 @@ export default function MyScreen() {
                 </Text>
               </TouchableOpacity>
 
-              <Text style={{...MyScreenStyles.infoSubTitle, marginTop: 8}}>
+              <TouchableOpacity
+                onPress={() => navigation.navigate('NotificationSettings')}>
+               <Text style={{...MyScreenStyles.infoSubTitle, marginTop: 8}}>
                 수신 설정
               </Text>
+              </TouchableOpacity>
 
               <View style={MyScreenStyles.line} />
 

--- a/src/screens/myScreen/MyScreenStyles.tsx
+++ b/src/screens/myScreen/MyScreenStyles.tsx
@@ -219,6 +219,74 @@ const MyScreenStyles = StyleSheet.create({
   next_button_text: {
     ...typography.subhead04,
   },
+  notificationContainer: {
+    flex: 1,
+    padding: 20,
+  },
+  notificationInfoTitle: {
+    fontSize: 18,
+    fontWeight: "bold",
+    marginBottom: 20,
+  },
+  notificationItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    height: 70,
+    paddingVertical: 13,
+    paddingHorizontal: 20,
+    borderBottomWidth: 1,
+    borderBottomColor: "#ddd",
+  },
+  notificationText: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#333",
+  },
+  notificationSubText: {
+    fontSize: 14,
+    color: "#666",
+    marginTop: 2,
+  },
+  
+
+
+  // // 마케팅 정보 수신 항목 스타일
+  // marketingItemContainer: {
+  //   marginTop: 30, // 기존 항목과 구분되는 간격
+  // },
+
+  // // 마케팅 항목 아래 선
+  // fullWidthLine: {
+  //   width: "100%", // 선이 가로로 꽉 차게
+  //   height: 1, // 선의 두께
+  //   backgroundColor: "#ddd", // 선 색상
+  //   marginTop: 11, // 11 만큼 간격 추가
+  // },
+
+  marketingItemContainer: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    height: 70,
+    paddingVertical: 13,
+    paddingHorizontal: 20,
+  },
+  
+  fullWidthLine: {
+    width: "100%", // 선이 가로로 꽉 차게
+    height: 1, // 선의 두께
+    backgroundColor: "#ddd", // 선 색상
+    marginTop: 11, // 11 만큼 간격 추가
+  },
+
+  // 마케팅 정보 수신 동의 약관 스타일
+  termsText: {
+    marginTop: 11, // 간격 설정
+    color: "#A5A5A5", // 회색 텍스트 색상
+    textDecorationLine: "underline", // 밑줄 추가
+    fontSize: 14,
+  },
 });
 
 export default MyScreenStyles;

--- a/src/screens/myScreen/MyScreenStyles.tsx
+++ b/src/screens/myScreen/MyScreenStyles.tsx
@@ -235,35 +235,23 @@ const MyScreenStyles = StyleSheet.create({
     height: 70,
     paddingVertical: 13,
     paddingHorizontal: 20,
-    borderBottomWidth: 1,
-    borderBottomColor: "#ddd",
+    borderBottomWidth: 0.75,
+    borderBottomColor: "#C1C1C1",
   },
   notificationText: {
     fontSize: 16,
     fontWeight: "bold",
-    color: "#333",
+    lineHeight: 22, 
+    letterSpacing: -0.3,
+    color: "#171717",
   },
   notificationSubText: {
     fontSize: 14,
+    lineHeight: 20, 
+    letterSpacing: -0.3,
     color: "#666",
     marginTop: 2,
   },
-  
-
-
-  // // 마케팅 정보 수신 항목 스타일
-  // marketingItemContainer: {
-  //   marginTop: 30, // 기존 항목과 구분되는 간격
-  // },
-
-  // // 마케팅 항목 아래 선
-  // fullWidthLine: {
-  //   width: "100%", // 선이 가로로 꽉 차게
-  //   height: 1, // 선의 두께
-  //   backgroundColor: "#ddd", // 선 색상
-  //   marginTop: 11, // 11 만큼 간격 추가
-  // },
-
   marketingItemContainer: {
     flexDirection: "row",
     alignItems: "center",
@@ -275,8 +263,8 @@ const MyScreenStyles = StyleSheet.create({
   
   fullWidthLine: {
     width: "100%", // 선이 가로로 꽉 차게
-    height: 1, // 선의 두께
-    backgroundColor: "#ddd", // 선 색상
+    height: 0.75, // 선의 두께
+    backgroundColor: "#A5A5A5", // 선 색상
     marginTop: 11, // 11 만큼 간격 추가
   },
 
@@ -296,7 +284,40 @@ const MyScreenStyles = StyleSheet.create({
     alignItems: "center",
     paddingVertical: 15,
     paddingHorizontal: 20,
-    marginTop: 39, // 🔥 리스트와 간격을 39만큼 추가
+    marginTop: 39, // 리스트와 간격을 39만큼 추가
+  },
+
+  marketingDetailsContainer: {
+    flex: 1,
+    backgroundColor: "#FFFFFF",
+  },
+  marketingDetailsScrollContainer: {
+    paddingBottom: 30, // 스크롤 마지막 항목 여백 추가
+  },
+  marketingDetailsInfoText: {
+    fontSize: 14,       // 글자 크기
+    lineHeight: 24,     // 줄 간격
+    letterSpacing: -0.3,// 글자 간격
+    color: "#000000",
+    marginTop: 28,  
+    marginLeft: 21, 
+    marginRight: 19, 
+  },
+  marketingDetailsSectionTitle: {
+    fontSize: 16,
+    fontWeight: "bold",
+    color: "#000000",
+    letterSpacing: -0.3,
+    marginTop: 24, 
+    marginLeft: 21, 
+    marginRight: 19, 
+  },
+  marketingDetailsListItem: {
+    fontSize: 14,
+    color: "#000000",
+    marginTop: 11, 
+    marginLeft: 21, 
+    marginRight: 19, 
   },
 });
 

--- a/src/screens/myScreen/MyScreenStyles.tsx
+++ b/src/screens/myScreen/MyScreenStyles.tsx
@@ -287,6 +287,17 @@ const MyScreenStyles = StyleSheet.create({
     textDecorationLine: "underline", // 밑줄 추가
     fontSize: 14,
   },
+  notificationLabelContainer: {
+    flex: 1, // 텍스트가 여러 줄일 때 Switch와 겹치지 않도록 설정
+  },
+  marketingContainer: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingVertical: 15,
+    paddingHorizontal: 20,
+    marginTop: 39, // 🔥 리스트와 간격을 39만큼 추가
+  },
 });
 
 export default MyScreenStyles;

--- a/src/screens/myScreen/NotificationSettings.tsx
+++ b/src/screens/myScreen/NotificationSettings.tsx
@@ -1,0 +1,120 @@
+import React, { useState } from "react";
+import { SafeAreaView, FlatList, Text, View, Switch } from "react-native";
+import MyScreenStyles from "./MyScreenStyles";
+
+// 알림 상태를 서버에 동기화하는 함수 (이미 구현했다고 가정)
+const updateNotificationSetting = async (id: string, enabled: boolean) => {
+  // 서버와 동기화하는 로직을 여기에 구현
+  console.log(`알림 ID: ${id}, 활성화 여부: ${enabled}`);
+};
+
+const NotificationSettings = () => {
+  // 알림 항목 및 상태
+  const [notifications, setNotifications] = useState([
+    { id: "1", label: "푸시 알림", enabled: false },
+    { id: "2", label: "게시판 활동", subLabel: "좋아요, 댓글, 인기 게시글 등", enabled: false },
+    { id: "3", label: "프리미엄 리뷰", subLabel: "추천, 인기 리뷰 등", enabled: false },
+    { id: "4", label: "해시태그 알림", subLabel: "해시태그가 포함된 게시글/리뷰", enabled: false },
+  ]);
+
+  // 푸시 알림을 켰을 때 하위 항목들을 켬
+  const togglePushNotification = async () => {
+    setNotifications((prev) =>
+      prev.map((item) => {
+        if (item.id === "1") {
+          const newEnabled = !item.enabled;
+          return { ...item, enabled: newEnabled };
+        }
+        return item;
+      })
+    );
+
+    // 푸시 알림을 켰을 때 하위 항목들도 모두 켬
+    const newEnabled = !notifications.find((item) => item.id === "1")?.enabled;
+    setNotifications((prev) =>
+      prev.map((item) =>
+        item.id !== "1" ? { ...item, enabled: newEnabled } : item
+      )
+    );
+
+    // 서버와 동기화
+    const updatedItem = notifications.find(item => item.id === "1");
+    if (updatedItem) {
+      await updateNotificationSetting("1", newEnabled);
+    }
+  };
+
+  // 하위 항목을 개별적으로 토글하고, 푸시 알림 상태를 확인
+  const toggleSubItem = async (id: string) => {
+    setNotifications((prev) => {
+      const newNotifications = prev.map((item) => {
+        if (item.id === id) {
+          return { ...item, enabled: !item.enabled };
+        }
+        return item;
+      });
+
+      // 푸시 알림 상태 업데이트 로직
+      const pushNotification = newNotifications.find((item) => item.id === "1");
+      const allSubItemsDisabled = newNotifications
+        .filter((item) => item.id !== "1")
+        .every((item) => !item.enabled);
+
+      // 하위 항목들이 모두 꺼졌을 때 푸시 알림도 꺼짐
+      if (pushNotification && allSubItemsDisabled) {
+        return newNotifications.map((item) =>
+          item.id === "1" ? { ...item, enabled: false } : item
+        );
+      }
+
+      // 하위 항목 중 하나라도 켜져 있으면 푸시 알림 켬
+      if (pushNotification && !allSubItemsDisabled) {
+        return newNotifications.map((item) =>
+          item.id === "1" ? { ...item, enabled: true } : item
+        );
+      }
+
+      return newNotifications;
+    });
+
+    // 서버와 동기화
+    const updatedItem = notifications.find(item => item.id === id);
+    if (updatedItem) {
+      await updateNotificationSetting(id, !updatedItem.enabled);
+    }
+  };
+
+  // 렌더링 함수
+  const renderItem = ({ item }: { item: { id: string; label: string; subLabel?: string; enabled: boolean } }) => (
+    <View style={MyScreenStyles.notificationItem}>
+      <View style={MyScreenStyles.notificationLabelContainer}>
+        <Text style={MyScreenStyles.notificationText}>{item.label}</Text>
+        {item.subLabel && <Text style={MyScreenStyles.notificationSubText}>{item.subLabel}</Text>}
+      </View>
+      <Switch
+        value={item.enabled}
+        onValueChange={() => {
+          // 푸시 알림일 경우
+          if (item.id === "1") {
+            togglePushNotification();
+          } else {
+            toggleSubItem(item.id);
+          }
+        }} // 토글 시 서버와 동기화
+        trackColor={{ false: "#ddd", true: "#FFF1BB" }} // #FFD700
+      />
+    </View>
+  );
+
+  return (
+    <SafeAreaView style={MyScreenStyles.container}>
+      <FlatList
+        data={notifications}
+        keyExtractor={(item) => item.id}
+        renderItem={renderItem}
+      />
+    </SafeAreaView>
+  );
+};
+
+export default NotificationSettings;

--- a/src/screens/myScreen/NotificationSettings.tsx
+++ b/src/screens/myScreen/NotificationSettings.tsx
@@ -1,15 +1,18 @@
 import React, { useState } from "react";
-import { SafeAreaView, FlatList, Text, View, Switch } from "react-native";
+import { SafeAreaView, FlatList, Text, View, Switch, TouchableOpacity } from "react-native";
+import { useNavigation } from "@react-navigation/native";
 import MyScreenStyles from "./MyScreenStyles";
 
-// 알림 상태를 서버에 동기화하는 함수 (이미 구현했다고 가정)
+type NavigationProp = {
+    navigate: (screen: 'MarketingDetails') => void;
+  };
+
 const updateNotificationSetting = async (id: string, enabled: boolean) => {
-  // 서버와 동기화하는 로직을 여기에 구현
   console.log(`알림 ID: ${id}, 활성화 여부: ${enabled}`);
 };
 
 const NotificationSettings = () => {
-  // 알림 항목 및 상태
+  const navigation = useNavigation();
   const [notifications, setNotifications] = useState([
     { id: "1", label: "푸시 알림", enabled: false },
     { id: "2", label: "게시판 활동", subLabel: "좋아요, 댓글, 인기 게시글 등", enabled: false },
@@ -17,57 +20,41 @@ const NotificationSettings = () => {
     { id: "4", label: "해시태그 알림", subLabel: "해시태그가 포함된 게시글/리뷰", enabled: false },
   ]);
 
-  // 푸시 알림을 켰을 때 하위 항목들을 켬
+  const [marketingOptIn, setMarketingOptIn] = useState(false);
+
   const togglePushNotification = async () => {
     setNotifications((prev) =>
-      prev.map((item) => {
-        if (item.id === "1") {
-          const newEnabled = !item.enabled;
-          return { ...item, enabled: newEnabled };
-        }
-        return item;
-      })
+      prev.map((item) => (item.id === "1" ? { ...item, enabled: !item.enabled } : item))
     );
 
-    // 푸시 알림을 켰을 때 하위 항목들도 모두 켬
     const newEnabled = !notifications.find((item) => item.id === "1")?.enabled;
     setNotifications((prev) =>
-      prev.map((item) =>
-        item.id !== "1" ? { ...item, enabled: newEnabled } : item
-      )
+      prev.map((item) => (item.id !== "1" ? { ...item, enabled: newEnabled } : item))
     );
 
-    // 서버와 동기화
-    const updatedItem = notifications.find(item => item.id === "1");
+    const updatedItem = notifications.find((item) => item.id === "1");
     if (updatedItem) {
       await updateNotificationSetting("1", newEnabled);
     }
   };
 
-  // 하위 항목을 개별적으로 토글하고, 푸시 알림 상태를 확인
   const toggleSubItem = async (id: string) => {
     setNotifications((prev) => {
-      const newNotifications = prev.map((item) => {
-        if (item.id === id) {
-          return { ...item, enabled: !item.enabled };
-        }
-        return item;
-      });
+      const newNotifications = prev.map((item) =>
+        item.id === id ? { ...item, enabled: !item.enabled } : item
+      );
 
-      // 푸시 알림 상태 업데이트 로직
       const pushNotification = newNotifications.find((item) => item.id === "1");
       const allSubItemsDisabled = newNotifications
         .filter((item) => item.id !== "1")
         .every((item) => !item.enabled);
 
-      // 하위 항목들이 모두 꺼졌을 때 푸시 알림도 꺼짐
       if (pushNotification && allSubItemsDisabled) {
         return newNotifications.map((item) =>
           item.id === "1" ? { ...item, enabled: false } : item
         );
       }
 
-      // 하위 항목 중 하나라도 켜져 있으면 푸시 알림 켬
       if (pushNotification && !allSubItemsDisabled) {
         return newNotifications.map((item) =>
           item.id === "1" ? { ...item, enabled: true } : item
@@ -77,16 +64,32 @@ const NotificationSettings = () => {
       return newNotifications;
     });
 
-    // 서버와 동기화
-    const updatedItem = notifications.find(item => item.id === id);
+    const updatedItem = notifications.find((item) => item.id === id);
     if (updatedItem) {
       await updateNotificationSetting(id, !updatedItem.enabled);
     }
   };
 
-  // 렌더링 함수
-  const renderItem = ({ item }: { item: { id: string; label: string; subLabel?: string; enabled: boolean } }) => (
-    <View style={MyScreenStyles.notificationItem}>
+  const toggleMarketingOptIn = async () => {
+    const newStatus = !marketingOptIn;
+    setMarketingOptIn(newStatus);
+    await updateNotificationSetting("marketing", newStatus);
+  };
+
+  const renderItem = ({
+    item,
+    index,
+  }: {
+    item: { id: string; label: string; subLabel?: string; enabled: boolean };
+    index: number;
+  }) => (
+    <View
+      style={[
+        MyScreenStyles.notificationItem,
+        ["2", "3", "4"].includes(item.id) && { backgroundColor: "#F2F2F2" },
+        index === notifications.length - 1 && { borderBottomWidth: 0 }, // 마지막 아이템이면 아래 선 제거
+      ]}
+    >
       <View style={MyScreenStyles.notificationLabelContainer}>
         <Text style={MyScreenStyles.notificationText}>{item.label}</Text>
         {item.subLabel && <Text style={MyScreenStyles.notificationSubText}>{item.subLabel}</Text>}
@@ -94,14 +97,13 @@ const NotificationSettings = () => {
       <Switch
         value={item.enabled}
         onValueChange={() => {
-          // 푸시 알림일 경우
           if (item.id === "1") {
             togglePushNotification();
           } else {
             toggleSubItem(item.id);
           }
-        }} // 토글 시 서버와 동기화
-        trackColor={{ false: "#ddd", true: "#FFF1BB" }} // #FFD700
+        }}
+        trackColor={{ false: "#ddd", true: "#FFF1BB" }}
       />
     </View>
   );
@@ -112,6 +114,31 @@ const NotificationSettings = () => {
         data={notifications}
         keyExtractor={(item) => item.id}
         renderItem={renderItem}
+        contentContainerStyle={{ paddingTop: 39 }}
+        ListFooterComponent={
+            <View style={{ paddingBottom: 10 }}>
+            <View style={[MyScreenStyles.marketingContainer, { marginTop: 39 }]}>
+              <Text style={MyScreenStyles.notificationText}>마케팅 정보 수신</Text>
+              <Switch
+                value={marketingOptIn}
+                onValueChange={toggleMarketingOptIn}
+                trackColor={{ false: "#ddd", true: "#FFF1BB" }}
+              />
+            </View>
+            {/* fullWidthLine을 "마케팅 정보 수신"에서 19.5만큼 떨어뜨리기 위해 marginTop 추가 */}
+             <View style={[MyScreenStyles.fullWidthLine, { marginTop: 0 }]} />
+          
+            {/* 마케팅 정보 수신 동의 약관 */}
+            <TouchableOpacity
+              onPress={() => navigation.navigate("MarketingDetails")}
+              style={{ alignSelf: "flex-start", marginLeft: 19, marginTop: 11 }}
+            >
+              <Text style={{ fontSize: 11, color: "#A5A5A5", textDecorationLine: "underline" }}>
+                마케팅 정보 수신 동의 약관
+              </Text>
+            </TouchableOpacity>
+          </View>
+        }
       />
     </SafeAreaView>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

- #75

## 📝작업 내용

- 스위치 로직 구현:
  푸시 알림 토글 on 시, 하위 3개 모두 on 하위 3개 토글은 개별로 설정 가능하나, 모두 off로 설정하면 상위 푸시 알림도 off
- '마케팅 정보 수신 동의 약관' 선택 시 '마케팅 정보 수신' 페이지로 이동

## 결과 화면
<img width="250" alt="스크린샷 2025-02-08 오후 6 39 40" src="https://github.com/user-attachments/assets/99b0ae25-5ad6-4a69-bc2f-830e18eaa5e8" />
<img width="250" alt="스크린샷 2025-02-08 오후 6 39 40" src="https://github.com/user-attachments/assets/10686afc-23e8-482a-a4e4-e93818e0ed5a" />


## 💬참고 사항

- 디자인 가이드에 맞게 컴포넌트 간의 간격과 레이아웃이 정확한지 검토 필요
- 텍스트 스타일(폰트 크기, 줄 간격 등)이 디자인 명세와 일치하는지 확인 필요
- API 연결을 고려한 확장성 있는 코드인지 검토 필요

>
