### PR TITLE
feat: 게시글 - 해시태그 UI 제작 및 API 연결

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -15,6 +15,7 @@ import StopReviewModal from './src/components/alertModal/StopReviewModal';
 import WriteScreen from './src/screens/write/post/WriteScreen';
 import PostScreen from './src/screens/dashboard/post/PostScreen';
 import ModifyScreen from './src/screens/write/post/ModifyScreen';
+// import PostHashtagScreen from './src/screens/dashboard/post/hashtag/PostHashtagScreen';
 import SaveScreen from './src/screens/write/save/SaveScreen';
 import DashboardSearchScreenList from './src/screens/dashboard/search/DashboardSearchScreenList';
 import DashboardSearchDefaultScreen from './src/screens/search/DashboardSearchDefaultScreen';
@@ -389,7 +390,7 @@ export default function App() {
               <Stack.Screen
                 name="PostScreen"
                 component={PostScreen}
-                initialParams={{postId: 5}}
+                // initialParams={{postId: 0}}
                 options={{headerShown: false}}
               />
               {/* 게시글 수정 페이지 */}
@@ -419,6 +420,12 @@ export default function App() {
                   <ModifyScreen {...props} setModifyData={setModifyData} />
                 )}
               </Stack.Screen>
+              {/* 게시글 해시태그 검색 페이지 */}
+              {/* <Stack.Screen
+                name="PostHashtagScreen"
+                component={PostHashtagScreen}
+                options={{headerShown: false}}
+              /> */}
               {/* 게시글 임시 저장 목록 페이지 */}
               <Stack.Screen
                 name="SaveScreen"
@@ -484,8 +491,8 @@ export default function App() {
                   ),
                 })}
               />
-            {/* 마이페이지: 수신 설정 페이지 */}
-            <Stack.Screen
+              {/* 마이페이지: 수신 설정 페이지 */}
+              <Stack.Screen
                 name="NotificationSettings"
                 component={NotificationSettings}
                 options={({navigation}) => ({
@@ -502,7 +509,7 @@ export default function App() {
               />
               {/* 마이페이지: 마케팅 정보 수신 페이지 */}
               <Stack.Screen
-                name="MarketingDetails" 
+                name="MarketingDetails"
                 component={MarketingDetails}
                 options={({navigation}) => ({
                   headerStyle: {

--- a/src/components/homeList/ItemPost.tsx
+++ b/src/components/homeList/ItemPost.tsx
@@ -77,9 +77,11 @@ const ItemPost: React.FC<PostProps> = ({postList}) => {
             <>
               <TouchableOpacity
                 style={ItemPostStyles.container}
-                onPress={navigation.navigate('PostScreen', {
-                  postId: item.id,
-                })}>
+                onPress={() =>
+                  navigation.navigate('PostScreen', {
+                    postId: item.id,
+                  })
+                }>
                 {category && (
                   <View
                     style={[

--- a/src/components/modifyDeleteModal/ModalModifyDelete.tsx
+++ b/src/components/modifyDeleteModal/ModalModifyDelete.tsx
@@ -103,8 +103,7 @@ const ModalModifyDelete: React.FC<ModalModifyDeleteProps> = ({
       <View style={ModalStyles.container}>
         <TouchableOpacity
           onPress={() => {
-            navigation.navigate('ModifyScreen');
-            // navigation.navigate('ModifyScreen', {postId: postId});
+            navigation.navigate('ModifyScreen', {postId: postId});
             setModalVisible(false);
           }}>
           <Text style={ModalStyles.text}>수정</Text>

--- a/src/components/navigation/Tabs.tsx
+++ b/src/components/navigation/Tabs.tsx
@@ -38,12 +38,12 @@ export default function Tabs({route}: {route: TabsRouteProp}) {
       icon: TabSvg.PremiumIcon,
       tabIcon: TabSvg.tabPremiumIcon,
     },
-    {
-      name: '게시판',
-      content: DashboardScreen,
-      icon: TabSvg.DashboardIcon,
-      tabIcon: TabSvg.tabDashboardIcon,
-    },
+    // {
+    //   name: '게시판',
+    //   content: DashboardScreen,
+    //   icon: TabSvg.DashboardIcon,
+    //   tabIcon: TabSvg.tabDashboardIcon,
+    // },
     {
       name: '티켓북',
       content: TicketBookScreen,

--- a/src/screens/dashboard/post/PostScreen.tsx
+++ b/src/screens/dashboard/post/PostScreen.tsx
@@ -187,6 +187,11 @@ const PostScreen: React.FC<PostScreenProps> = ({route}) => {
     }
   };
 
+  const handleHashtagPress = (tag: string) => {
+    console.log('클릭된 해시태그:', tag);
+    navigation.navigate('PostHashtagScreen', {hashTag: tag});
+  };
+
   return (
     <>
       <SafeAreaView style={PostStyles.container}>
@@ -268,11 +273,16 @@ const PostScreen: React.FC<PostScreenProps> = ({route}) => {
               {postData?.hashtags?.length !== 0 && (
                 <View style={PostStyles.line} />
               )}
-              <TouchableOpacity style={PostStyles.containerHashtag}>
-                <Text style={PostStyles.textHashtag}>
-                  {postData?.hashtags?.join(' ') || ''}
-                </Text>
-              </TouchableOpacity>
+              <View style={PostStyles.containerHashtagWrapper}>
+                {postData?.hashtags?.map((tag, index) => (
+                  <TouchableOpacity
+                    key={index}
+                    onPress={() => handleHashtagPress(tag)} // 해시태그 클릭 시 동작
+                  >
+                    <Text style={PostStyles.textHashtag}>{tag}</Text>
+                  </TouchableOpacity>
+                ))}
+              </View>
               {/* 좋아요 및 댓글 */}
               <View style={PostStyles.containerCommentLikeItems}>
                 <TouchableOpacity

--- a/src/screens/dashboard/post/PostStyles.tsx
+++ b/src/screens/dashboard/post/PostStyles.tsx
@@ -74,9 +74,12 @@ const HomeStyles = StyleSheet.create({
     backgroundColor: Colors.gray_04,
     marginVertical: 26,
   },
-  containerHashtag: {
+  containerHashtagWrapper: {
     marginHorizontal: 24,
     marginBottom: 15,
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 5,
   },
   textHashtag: {
     ...body01,

--- a/src/screens/dashboard/post/hashtag/PostHashtagScreen.tsx
+++ b/src/screens/dashboard/post/hashtag/PostHashtagScreen.tsx
@@ -1,0 +1,108 @@
+import React, {useState} from 'react';
+import {RouteProp, useRoute} from '@react-navigation/native';
+import {
+  SafeAreaView,
+  Text,
+  View,
+  TouchableOpacity,
+  TextInput,
+} from 'react-native';
+import {useNavigation} from '@react-navigation/native';
+import {SvgXml} from 'react-native-svg';
+import PostStyles from '../PostStyles';
+import PostHashtagStyles from './PostHashtagStyles';
+import {SearchIcon} from '@/assets/icons/search/SearchIcon';
+
+// 1. Stack Param 타입 정의 (선택)
+type RootStackParamList = {
+  PostHashtagScreen: {hashTag: string};
+};
+
+const PostHashtagScreen: React.FC = () => {
+  const route = useRoute<RouteProp<RootStackParamList, 'PostHashtagScreen'>>();
+  const {hashTag} = route.params;
+  const [text, setText] = useState<string>(hashTag);
+  const navigation = useNavigation();
+  const [selectedTab, setSelectedTab] = useState('Entire');
+
+  if (text.trim() === '') {
+    return <DefaultView />;
+  }
+  // 검색 중 화면
+  return <DashboardSearchScreen postData={postData} />;
+};
+
+  return (
+    <SafeAreaView style={PostStyles.container}>
+      {/* 검색바 */}
+      <View style={PostHashtagStyles.searchBarContainer}>
+        <View style={PostHashtagStyles.searchBar}>
+          {/* <TouchableOpacity onPress={() => fetchSearchList(text)}> */}
+          <TouchableOpacity>
+            <SvgXml
+              xml={SearchIcon.searchIcon}
+              style={PostHashtagStyles.icon}
+            />
+          </TouchableOpacity>
+          <TextInput
+            style={PostHashtagStyles.textInput}
+            value={text}
+            onChangeText={setText}
+            placeholder="해시태그 검색"
+            // onSubmitEditing={() => fetchSearchList(text)}
+          />
+          {text.length > 0 && (
+            <TouchableOpacity
+              style={PostHashtagStyles.clearButton}
+              onPress={() => {
+                setText('');
+              }}>
+              <SvgXml xml={SearchIcon.closeIcon} />
+            </TouchableOpacity>
+          )}
+        </View>
+        <TouchableOpacity onPress={() => navigation.goBack()}>
+          <Text>취소</Text>
+        </TouchableOpacity>
+      </View>
+
+      <View style={PostHashtagStyles.tabContainer}>
+        {['Entire', 'Information', 'Review', 'Actor', 'Free'].map(
+          (tab, index) => (
+            <TouchableOpacity
+              key={index}
+              onPress={() => setSelectedTab(tab)}
+              style={[
+                PostHashtagStyles.tabButton,
+                selectedTab === tab && PostHashtagStyles.activeTabButton,
+              ]}>
+              <Text
+                style={[
+                  PostHashtagStyles.tabText,
+                  selectedTab === tab && PostHashtagStyles.activeTabText,
+                ]}>
+                {tab === 'Entire'
+                  ? '전체'
+                  : tab === 'Information'
+                  ? '정보'
+                  : tab === 'Review'
+                  ? '후기'
+                  : tab === 'Actor'
+                  ? '배우'
+                  : '자유'}
+              </Text>
+              {selectedTab === tab && (
+                <View style={PostHashtagStyles.activeTabUnderline} />
+              )}
+            </TouchableOpacity>
+          ),
+        )}
+      </View>
+
+      {/* 검색 바 하단 화면 */}
+      {renderComponent()}
+    </SafeAreaView>
+  );
+};
+
+export default PostHashtagScreen;

--- a/src/screens/dashboard/post/hashtag/PostHashtagStyles.tsx
+++ b/src/screens/dashboard/post/hashtag/PostHashtagStyles.tsx
@@ -1,0 +1,65 @@
+import {StyleSheet} from 'react-native';
+import Colors from '@/assets/colors/Colors';
+import {typography} from '../../../../styles/typography';
+
+const {subhead02, subhead03, body01, caption} = typography;
+
+const PostHashtagStyles = StyleSheet.create({
+  searchBarContainer: {
+    flexDirection: 'row',
+    margin: 20,
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  searchBar: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    borderRadius: 10,
+    backgroundColor: Colors.gray_03,
+    width: 292,
+    height: 40,
+  },
+  icon: {
+    marginRight: 10,
+  },
+  textInput: {
+    flex: 1,
+    fontSize: 15,
+  },
+  clearButton: {
+    marginLeft: 10,
+  },
+  tabButton: {
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    height: 44,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  tabContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-around',
+  },
+  tabText: {
+    ...subhead03,
+    color: Colors.gray_06,
+    textAlign: 'center',
+  },
+  activeTabText: {
+    ...subhead03,
+    color: Colors.black,
+  },
+  activeTabButton: {
+    position: 'relative',
+  },
+  activeTabUnderline: {
+    position: 'absolute',
+    bottom: 0,
+    height: 2,
+    width: 67.3,
+    backgroundColor: Colors.sub_04,
+  },
+});
+
+export default PostHashtagStyles;

--- a/src/screens/premium/PremiumScreen.tsx
+++ b/src/screens/premium/PremiumScreen.tsx
@@ -107,6 +107,7 @@ export default function PremiumScreen() {
     } catch (error) {
       console.log('error: ', error);
       Alert.alert('프리미엄 리뷰 조회 중에 문제가 발생했습니다.');
+      console.error('프리미엄 리뷰 조회 오류: ', error);
     }
   };
 

--- a/src/screens/write/post/ModifyScreen.tsx
+++ b/src/screens/write/post/ModifyScreen.tsx
@@ -1,4 +1,5 @@
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useCallback} from 'react';
+import {useFocusEffect} from '@react-navigation/native';
 import {
   SafeAreaView,
   ScrollView,
@@ -108,9 +109,11 @@ const ModifyScreen: React.FC<ModifyScreenRouteProps> = ({
     }
   };
 
-  useEffect(() => {
-    fetchGetPost();
-  }, []);
+  useFocusEffect(
+    useCallback(() => {
+      fetchGetPost();
+    }, []),
+  );
 
   // App.tsx로 props 전달
   useEffect(() => {

--- a/src/screens/write/post/WriteScreen.tsx
+++ b/src/screens/write/post/WriteScreen.tsx
@@ -7,6 +7,7 @@ import {
   TouchableOpacity,
   TextInput,
   Image,
+  Alert,
 } from 'react-native';
 import {SvgXml} from 'react-native-svg';
 import {useNavigation, NavigationProp} from '@react-navigation/native';
@@ -19,6 +20,7 @@ import {SelectImage} from '@/components/selectImage/SelectImage';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import CheckTempModal from '@/components/alertModal/CheckTempModal';
 import {useRoute, RouteProp} from '@react-navigation/native';
+import {getPost} from '@/api/post.api';
 
 interface PostData {
   title: string;
@@ -68,6 +70,8 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
   const [selectedSubTitle, setSelectedSubtitle] = useState('');
   const [topButton, setTopButton] = useState('');
   const [bottomButton, setBottomButton] = useState('');
+  const [savedPosts, setSavedPosts] = useState<any[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
   const navigation = useNavigation<NavigationProp<RootStackParamList>>();
 
   const dashboardList = [
@@ -77,6 +81,7 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     '배우 게시판',
     '자유 게시판',
   ];
+
   const pressDashboard = () => {
     setDashboardModalVisible(true);
     setModalTitle('게시판');
@@ -114,6 +119,7 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     PERFORMANCE_REVIEW: '공연 감상',
   };
 
+  // 임시저장 글 유무에 따라 띄우는 모달
   const openModal = (
     title: string,
     subTitle: string,
@@ -130,7 +136,7 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
   // 임시저장 글 유무에 따라 띄우는 모달
   const handleJudgeTempList = async () => {
     const storedData = await AsyncStorage.getItem('temporaryPosts');
-    console.log('스토리지에 저장된 임시 저장 글: ', storedData);
+    // console.log('스토리지에 저장된 임시 저장 글: ', storedData);
     const parsedData = JSON.parse(storedData || '[]');
 
     if (parsedData.length > 0) {
@@ -138,6 +144,12 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     }
   };
 
+  // 임시 저장 글 불러오기
+  useEffect(() => {
+    handleJudgeTempList();
+  }, []);
+
+  // 게시판 선택에 따른 카테고리 변경
   useEffect(() => {
     if (post_type === '정보 게시판') {
       setCategoryDisabled(false);
@@ -151,10 +163,7 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     }
   }, [post_type]);
 
-  useEffect(() => {
-    handleJudgeTempList();
-  }, []);
-
+  // 카테고리 선택
   const pressCategory = () => {
     if (!categoryDisabled) {
       setCategoryModalVisible(true);
@@ -162,11 +171,13 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     }
   };
 
+  // 내용 변경 시 해시태그 추출
   const handleContentChange = (text: string) => {
     setContent(text);
     setHashTags(text.match(/#[^\s#]+/g) || []);
   };
 
+  // 이미지 선택
   const handleSelectImage = async () => {
     const imageUrl = await SelectImage(setPhotoCount);
     if (imageUrl) {
@@ -174,6 +185,7 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     }
   };
 
+  // 이미지 삭제
   const handleRemoveImage = (index: number) => {
     setImgUrls(prev => prev.filter((_, i) => i !== index));
     setPhotoCount(prev => prev - 1);
@@ -191,7 +203,92 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
     });
   }, [title, content, post_type, category, imgUrls]);
 
-  // 상태 업데이트
+  // 임시 저장 글에서 넘어온 데이터 작성 페이지에 그대로 띄우기
+  useEffect(() => {
+    if (route.params?.postData) {
+      const postData = route.params?.postData;
+      const mappedCategory = categoryMapping[postData.category] || '';
+      const mappedPostType = postTypeMapping[postData.post_type] || '';
+
+      console.log('임시저장 글에서 넘어온 데이터: ', postData);
+
+      setTitle(postData.title);
+      setContent(postData.content);
+      setPostType(mappedPostType);
+      setCategory(mappedCategory);
+      setHashTags(postData.hashTags || []);
+      setImgUrls(postData.post_images || []);
+    }
+  }, [route.params?.postData]);
+
+  // 임시 저장 글 조회 후 가장 최신 글 판단
+  type Post = {
+    post_id: number;
+    modified_at: string;
+  };
+
+  const fetchSavedPosts = async (): Promise<any | null> => {
+    try {
+      const storedData = await AsyncStorage.getItem('temporaryPosts');
+      const parsedData = JSON.parse(storedData || '[]');
+
+      const now = new Date();
+      const twoWeeksInSeconds = 14 * 24 * 60 * 60;
+
+      const validPosts = parsedData.filter((post: Post) => {
+        const past = new Date(post.modified_at);
+        const diffInSeconds = Math.floor(
+          (now.getTime() - past.getTime()) / 1000,
+        );
+        return diffInSeconds < twoWeeksInSeconds;
+      });
+
+      if (validPosts.length === 0) {
+        setSavedPosts([]);
+        await AsyncStorage.setItem('temporaryPosts', JSON.stringify([]));
+        return;
+      }
+
+      // 최신 글을 불러오기 위해 수정일 기준으로 정렬
+      validPosts.sort(
+        (a: Post, b: Post) =>
+          new Date(b.modified_at).getTime() - new Date(a.modified_at).getTime(),
+      );
+      const latestPost = validPosts[0];
+      const response = await getPost(latestPost.post_id);
+      const latestPostData = response.data.data;
+
+      setSavedPosts([latestPostData]);
+      console.log('가장 최신 임시 저장 글: ', latestPostData);
+
+      return latestPostData;
+    } catch (error) {
+      console.error('Error fetching saved posts:', error);
+      Alert.alert(
+        '임시 저장 글을 불러오는 도중 문제가 발생했습니다. 다시 시도해주세요.',
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const bringTemporaryPost = async () => {
+    const latestPost = await fetchSavedPosts();
+    if (latestPost) {
+      // 이걸 그대로 postData에 써도 되고, useState 초기화해도 됨
+
+      const mappedCategory = categoryMapping[latestPost.category] || '';
+      const mappedPostType = postTypeMapping[latestPost.post_type] || '';
+
+      setTitle(latestPost.title || '');
+      setContent(latestPost.content || '');
+      setPostType(mappedPostType || '게시판 선택');
+      setCategory(mappedCategory || '카테고리 선택');
+      setHashTags(latestPost.hashTags || []);
+      setImgUrls(latestPost.imgUrls || []);
+    }
+  };
+
   useEffect(() => {
     if (route.params?.postData) {
       const postData = route.params?.postData;
@@ -355,7 +452,8 @@ const WriteScreen: React.FC<WriteScreenProps> = ({setPostData}) => {
         subTitle={selectedSubTitle}
         topButton={topButton}
         bottomButton={bottomButton}
-        topButtonAction={() => navigation.navigate('SaveScreen')}
+        topButtonAction={() => bringTemporaryPost()}
+        // topButtonAction={() => navigation.navigate('SaveScreen')}
       />
     </>
   );

--- a/src/screens/write/review/PremiumWriteStyles.tsx
+++ b/src/screens/write/review/PremiumWriteStyles.tsx
@@ -51,6 +51,7 @@ const PremiumWriteStyles = StyleSheet.create({
     ...typography.subhead03,
     zIndex: 1,
     marginVertical: 14,
+    width: 180,
   },
   icons: {
     flexDirection: 'column',
@@ -67,6 +68,7 @@ const PremiumWriteStyles = StyleSheet.create({
     fontSize: 10,
     lineHeight: 18,
     letterSpacing: -0.3,
+    width: 170,
   },
   white: {
     position: 'absolute',

--- a/src/screens/write/review/step/PremiumStep1Screen.tsx
+++ b/src/screens/write/review/step/PremiumStep1Screen.tsx
@@ -103,27 +103,35 @@ const PremiumStep1Screen: React.FC<PremiumProp> = ({goToNext, saveData}) => {
               />
               <View style={PremiumWriteStyles.icons}>
                 <Text
-                  style={[PremiumWriteStyles.list_title, {color: titleColor}]}>
+                  style={[PremiumWriteStyles.list_title, {color: titleColor}]}
+                  numberOfLines={1}
+                  ellipsizeMode="tail">
                   {item.musical_title}
                 </Text>
                 <View style={PremiumWriteStyles.icon_container}>
                   <SvgXml xml={time_icon} style={PremiumWriteStyles.icon} />
                   <Text
-                    style={[PremiumWriteStyles.list_text, {color: textColor}]}>
+                    style={[PremiumWriteStyles.list_text, {color: textColor}]}
+                    numberOfLines={1}
+                    ellipsizeMode="tail">
                     {item.location}
                   </Text>
                 </View>
                 <View style={PremiumWriteStyles.icon_container}>
                   <SvgXml xml={seat_icon} style={PremiumWriteStyles.icon} />
                   <Text
-                    style={[PremiumWriteStyles.list_text, {color: textColor}]}>
+                    style={[PremiumWriteStyles.list_text, {color: textColor}]}
+                    numberOfLines={1}
+                    ellipsizeMode="tail">
                     {item.seat}
                   </Text>
                 </View>
                 <View style={PremiumWriteStyles.icon_container}>
                   <SvgXml xml={person_icon} style={PremiumWriteStyles.icon} />
                   <Text
-                    style={[PremiumWriteStyles.list_text, {color: textColor}]}>
+                    style={[PremiumWriteStyles.list_text, {color: textColor}]}
+                    numberOfLines={1}
+                    ellipsizeMode="tail">
                     {item.actors}
                   </Text>
                 </View>

--- a/src/screens/write/review/step/PremiumStep3Screen.tsx
+++ b/src/screens/write/review/step/PremiumStep3Screen.tsx
@@ -45,8 +45,7 @@ const PremiumStep3Screen: React.FC<PremiumProp> = ({
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const [searchText, setSearchText] = useState<string>('');
 
-  const isButtonDisabled =
-    !selectedId || searchText.trim() === '' || searchText.trim().length < 20;
+  const isButtonDisabled = !selectedId || searchText.trim() === '';
 
   const renderItem: ListRenderItem<ReviewItems> = ({item}) => {
     const isSelected = selectedId === item.id;
@@ -120,7 +119,7 @@ const PremiumStep3Screen: React.FC<PremiumProp> = ({
               style={PremiumWriteStyles.seat_input}
               value={searchText}
               onChangeText={setSearchText}
-              placeholder="시야에 대한 후기를 작성해주세요. (최소 20자)"
+              placeholder="시야에 대한 후기를 작성해주세요."
               multiline={true}
             />
           </View>

--- a/src/screens/write/review/step/PremiumStep4Screen.tsx
+++ b/src/screens/write/review/step/PremiumStep4Screen.tsx
@@ -59,10 +59,7 @@ const PremiumStep4Screen: React.FC<PremiumProp> = ({
     // console.log(selectedId);
   };
 
-  const isButtonDisabled =
-    !selectedOption ||
-    searchText.trim() === '' ||
-    searchText.trim().length < 20;
+  const isButtonDisabled = !selectedOption || searchText.trim() === '';
 
   return (
     <>
@@ -114,7 +111,7 @@ const PremiumStep4Screen: React.FC<PremiumProp> = ({
               style={PremiumWriteStyles.seat_input}
               value={searchText}
               onChangeText={setSearchText}
-              placeholder="선택한 이유를 작성해주세요. (최소 20자)"
+              placeholder="선택한 이유를 작성해주세요."
               multiline={true}
             />
           </View>

--- a/src/screens/write/review/step/PremiumStep5Screen.tsx
+++ b/src/screens/write/review/step/PremiumStep5Screen.tsx
@@ -58,10 +58,7 @@ const PremiumStep5Screen: React.FC<PremiumProp> = ({
     // console.log(selectedId);
   };
 
-  const isButtonDisabled =
-    !selectedOption ||
-    searchText.trim() === '' ||
-    searchText.trim().length < 20;
+  const isButtonDisabled = !selectedOption || searchText.trim() === '';
 
   return (
     <>
@@ -113,7 +110,7 @@ const PremiumStep5Screen: React.FC<PremiumProp> = ({
               style={PremiumWriteStyles.seat_input}
               value={searchText}
               onChangeText={setSearchText}
-              placeholder="선택한 이유를 작성해주세요. (최소 20자)"
+              placeholder="선택한 이유를 작성해주세요."
               multiline={true}
             />
           </View>

--- a/src/screens/write/review/step/PremiumStep6Screen.tsx
+++ b/src/screens/write/review/step/PremiumStep6Screen.tsx
@@ -109,8 +109,7 @@ const PremiumStep6Screen: React.FC<PremiumProp> = ({
     setModalVisible(true);
   };
 
-  const isButtonDisabled =
-    searchText.trim() === '' || searchText.trim().length < 20;
+  const isButtonDisabled = searchText.trim() === '';
 
   const [loading, setLoading] = useState(false);
   const navigation = useNavigation<NavigationProp>();
@@ -282,7 +281,7 @@ const PremiumStep6Screen: React.FC<PremiumProp> = ({
               style={PremiumWriteStyles.seat_input}
               value={searchText}
               onChangeText={setSearchText}
-              placeholder="선택한 이유를 작성해주세요. (최소 20자)"
+              placeholder="선택한 이유를 작성해주세요."
               multiline={true}
             />
           </View>
@@ -332,3 +331,131 @@ const PremiumStep6Screen: React.FC<PremiumProp> = ({
 };
 
 export default PremiumStep6Screen;
+
+// import React, {useState} from 'react';
+// import {View, Dimensions, Pressable} from 'react-native';
+// import Svg, {Polygon, Circle, Text as SvgText} from 'react-native-svg';
+// import {RootStackParamList} from 'types';
+// import {NativeStackNavigationProp} from '@react-navigation/native-stack';
+
+// type PremiumProp = {
+//   goToNext: any;
+//   saveData: any;
+//   stepData: any;
+//   reviewId?: number;
+// };
+
+// type NavigationProp = NativeStackNavigationProp<
+//   RootStackParamList,
+//   'PremiumMyScreen'
+// >;
+
+// const PremiumStep6Screen: React.FC<PremiumProp> = ({
+//   goToNext,
+//   saveData,
+//   stepData,
+//   reviewId,
+// }) => {
+//   const screenWidth = Dimensions.get('window').width;
+//   const chartSize = screenWidth - 40;
+//   const center = chartSize / 2;
+//   const radius = chartSize / 2 - 40;
+//   const maxScore = 5;
+
+//   const categories = ['속도', '정확도', '안정성', '디자인', '기능성'];
+//   const angle = (2 * Math.PI) / categories.length;
+//   const [scores, setScores] = useState(Array(categories.length).fill(3)); // 초기 점수 3점
+
+//   const calculatePoints = customScores => {
+//     return customScores.map((score, index) => {
+//       const x = center + radius * (score / maxScore) * Math.sin(index * angle);
+//       const y = center - radius * (score / maxScore) * Math.cos(index * angle);
+//       return {x, y};
+//     });
+//   };
+
+//   const handleTouch = index => {
+//     setScores(prevScores =>
+//       prevScores.map((score, i) =>
+//         i === index ? (score < maxScore ? score + 1 : 1) : score,
+//       ),
+//     );
+//   };
+
+//   const points = calculatePoints(scores);
+//   const polygonPoints = points.map(({x, y}) => `${x},${y}`).join(' ');
+
+//   return (
+//     <View style={{alignItems: 'center', marginTop: 40}}>
+//       <Svg width={chartSize} height={chartSize}>
+//         {/* 배경 다각형들 */}
+//         {[...Array(maxScore)].map((_, i) => {
+//           const r = radius * ((i + 1) / maxScore);
+//           const bgPoints = calculatePoints(Array(categories.length).fill(i + 1))
+//             .map(({x, y}) => `${x},${y}`)
+//             .join(' ');
+//           return (
+//             <Polygon
+//               key={i}
+//               points={bgPoints}
+//               fill="none"
+//               stroke="#ccc"
+//               strokeWidth="1"
+//             />
+//           );
+//         })}
+
+//         {/* 사용자 점수 영역 */}
+//         <Polygon
+//           points={polygonPoints}
+//           fill="rgba(255, 215, 48, 0.4)"
+//           stroke="#FFD630"
+//           strokeWidth="2"
+//         />
+
+//         {/* 꼭짓점 터치 원 */}
+//         {points.map(({x, y}, index) => (
+//           <React.Fragment key={index}>
+//             {/* 시각적 점 */}
+//             <Circle cx={x} cy={y} r={5} fill="#FFD630" />
+
+//             {/* 터치 감지 원 (투명) */}
+//             <Pressable
+//               key={`touch-${index}`}
+//               onPress={() => handleTouch(index)}
+//               style={{
+//                 position: 'absolute',
+//                 top: y + 40 - 20,
+//                 left: x + (screenWidth - chartSize) / 2 - 20,
+//                 width: 40,
+//                 height: 40,
+//                 borderRadius: 20,
+//                 backgroundColor: 'transparent', // 디버깅 시 rgba 색상 써도 됨
+//               }}
+//             />
+//           </React.Fragment>
+//         ))}
+
+//         {/* 텍스트 라벨 */}
+//         {categories.map((label, index) => {
+//           const x = center + (radius + 20) * Math.sin(index * angle);
+//           const y = center - (radius + 20) * Math.cos(index * angle);
+
+//           return (
+//             <SvgText
+//               key={`label-${index}`}
+//               x={x}
+//               y={y}
+//               fontSize="12"
+//               fill="#333"
+//               textAnchor="middle">
+//               {label}
+//             </SvgText>
+//           );
+//         })}
+//       </Svg>
+//     </View>
+//   );
+// };
+
+// export default PremiumStep6Screen;

--- a/types.d.ts
+++ b/types.d.ts
@@ -15,6 +15,7 @@ export type RootStackParamList = {
   PremiumMyScreen: {reviewId: number};
   PostScreen: {postId: number};
   ModifyScreen: {postId: number};
+  // PostHashtagScreen: {hashTag: string};
   SaveScreen: undefined;
   DashboardSearchScreenList: {postData: any; text: string};
   DashboardSearchDefaultScreen: undefined;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #67 

## 📝작업 내용
- MVP 탭에 맞춰서 게시판 제외
- 해시태그 누를 시 이동할 수 있는 해시태그용 페이지 기초 UI 제작 (추후 수정 필요)
- 게시글 임시 저장 글 불러오는 방식 수정: 네이버 블로그처럼 모달에서 "이어쓰기" 누를 시 가장 최근 글이 불러와짐

## 결과 화면

## 💬참고 사항
> 추후 수정이 필요한 부분들
