### PR TITLE
refactor: 프리미엄 tab 페이지 리팩토링

### DIFF
--- a/src/api/review.api.tsx
+++ b/src/api/review.api.tsx
@@ -1,4 +1,57 @@
-import httpApi from './http.api';
+import httpApi, {IResponse} from './http.api';
+
+export type IReviewParams = {
+  size: number;
+  sort: string;
+  cursor?: number;
+  tag?: string;
+  search_word?: string;
+};
+
+export type IReviewRating = {
+  number_rating: number;
+  story_rating: number;
+  revisit_rating: number;
+  actor_rating: number;
+  performance_rating: number;
+  total_rating: number;
+  rating_review: string;
+};
+
+export type ITicketReview = {
+  review_id: number;
+  user_id: number;
+  title: string;
+  nickname: string;
+  elapsed_time: string;
+  view_count: number;
+  like_count: number;
+  rating?: IReviewRating;
+};
+
+export type Pageable = {
+  page_number: number;
+  page_size: number;
+  sort: {
+    empty: boolean;
+    sorted: boolean;
+    unsorted: boolean;
+  };
+  offset: number;
+  paged: boolean;
+  unpaged: boolean;
+};
+
+export type ReviewListData = {
+  content: ITicketReview[];
+  pageable: Pageable;
+  first: boolean;
+  last: boolean;
+  size: number;
+  number: number;
+  number_of_elements: number;
+  empty: boolean;
+};
 
 export const postTicketReview = (ticket_id: number, requestData: any) => {
   return httpApi.post(`/api/v1/review/${ticket_id}`, requestData);
@@ -16,47 +69,25 @@ export const getReviewSearchSuggestions = (keyword: string) => {
 };
 
 // 프리미엄 리뷰 리스트 조회
-export const getSafeTicketReviewList = async (
-  size: number,
-  sort: string,
-  cursor?: number,
-  tag?: string,
-  search_word?: string,
-) => {
+export const getSafeTicketReviewList = async (params: IReviewParams) => {
   try {
-    const response = await getTicketReviewList(
-      size,
-      sort,
-      cursor,
-      tag,
-      search_word,
-    );
-    return response;
+    const data = await getTicketReviewList(params);
+    return data;
   } catch (error: any) {
+    // 태그에 해당하는 리뷰가 없는 경우 빈 배열 반환
     if (error.response?.status === 404) {
-      return {data: {content: []}}; // 태그에 해당하는 리뷰가 없는 경우 빈 배열 반환
+      return { content: [], pageable: {}, first: true, last: true, size: 0, number: 0, number_of_elements: 0, empty: true }; 
     }
     throw error;
   }
 };
 
-export const getTicketReviewList = (
-  size: number,
-  sort: string,
-  cursor?: number,
-  tag?: string,
-  search_word?: string,
-) => {
-  const requestParams = {
-    size,
-    sort,
-    cursor,
-    tag,
-    search_word,
-  };
-  return httpApi.get(`/api/v1/review/list`, {
-    params: requestParams,
-  });
+export const getTicketReviewList = async (params: IReviewParams) => {
+  const {data} = await httpApi.get<IResponse<ReviewListData>>(
+    `/api/v1/review/list`,
+    {params},
+  );
+  return data.data; // ReviewListData
 };
 
 // 현재 보고 있는 리뷰를 제외한 유저의 리뷰 리스트 조회

--- a/src/api/review.api.tsx
+++ b/src/api/review.api.tsx
@@ -16,6 +16,30 @@ export const getReviewSearchSuggestions = (keyword: string) => {
 };
 
 // 프리미엄 리뷰 리스트 조회
+export const getSafeTicketReviewList = async (
+  size: number,
+  sort: string,
+  cursor?: number,
+  tag?: string,
+  search_word?: string,
+) => {
+  try {
+    const response = await getTicketReviewList(
+      size,
+      sort,
+      cursor,
+      tag,
+      search_word,
+    );
+    return response;
+  } catch (error: any) {
+    if (error.response?.status === 404) {
+      return {data: {content: []}}; // 태그에 해당하는 리뷰가 없는 경우 빈 배열 반환
+    }
+    throw error;
+  }
+};
+
 export const getTicketReviewList = (
   size: number,
   sort: string,
@@ -55,4 +79,4 @@ export const getTicketReviewImage = (cycle: number) => {
 
 export const deleteTicketReview = (review_id: number) => {
   return httpApi.delete(`/api/v1/review/${review_id}`);
-}
+};

--- a/src/app/premium/PremiumScreen/index.tsx
+++ b/src/app/premium/PremiumScreen/index.tsx
@@ -1,25 +1,13 @@
-import React, {useState, useEffect, useCallback} from 'react';
-import {useFocusEffect} from '@react-navigation/native';
-import {
-  SafeAreaView,
-  View,
-  Text,
-  TouchableOpacity,
-  Alert,
-  FlatList,
-  ActivityIndicator,
-} from 'react-native';
+import React, {useState} from 'react';
+import {SafeAreaView, View, Text, TouchableOpacity} from 'react-native';
 import {SvgXml} from 'react-native-svg';
 import {NavigationProp, useNavigation} from '@react-navigation/native';
 import {DashboardIcon} from '@/assets/icons/dashboard/DashboardIcon';
 import IconSearch from '@/assets/icons/dashboard/IconSearch';
 import IconNotification from '@/assets/icons/dashboard/IconNotification';
-import PopularReviews from '@/components/premium/PopularReviews';
-import Tags from '@/components/premium/Tags';
-import ItemReview from '@/components/premium/ItemReview';
+import ReviewLists from '@/features/premium/modules/ReviewLists';
+import TodayPopularReviews from '@/features/premium/modules/TodayPopularReviews';
 import ToolTipModal from '@/components/alertModal/ToolTipModal';
-import {getPopularPremiumReviews} from '@/api/premium.api';
-import {getTicketReviewList} from '@/api/review.api';
 import PremiumStyles from './style';
 
 type RootStackParamList = {
@@ -35,11 +23,7 @@ export default function PremiumScreen() {
     right: 0,
   });
   const [reviewModalVisible, setReviewModalVisible] = useState(true);
-  const [popularPremiumReviews, setPopularPremiumReviews] = useState([]);
-  const [reviewData, setReviewData] = useState<any[]>([]); // 전체 리뷰 리스트
-  const [cursor, setCursor] = useState<number | undefined>(undefined); // 마지막 id
   const [hasMore, setHasMore] = useState(true); // 더 불러올 데이터가 있는지 확인
-  const [isLoading, setIsLoading] = useState(true); // 초기 로딩
   const [isFetching, setIsFetching] = useState(false); // 중복 요청 방지
   const [tag, setTag] = useState<string | undefined>(undefined);
 
@@ -51,54 +35,6 @@ export default function PremiumScreen() {
   const handleModalCancel = () => {
     setReviewModalVisible(false);
   };
-
-  // 무한 스크롤 적용 필요
-  const fetchReviewList = async () => {
-    try {
-      const response = await getTicketReviewList(
-        100,
-        'createdat',
-        undefined,
-        tag,
-        undefined,
-      );
-      const reviewData = response.data.data.content;
-
-      console.log('프리미엄 리뷰 조회 결과: ', reviewData);
-
-      if (reviewData.length === 0) {
-        setReviewData([]);
-      } else {
-        setReviewData(reviewData);
-      }
-    } catch (error: any) {
-      console.log('error: ', error);
-      if (error.response?.status === 404) {
-        setReviewData([]); // 데이터 없다고 간주
-      } else {
-        Alert.alert('프리미엄 리뷰 조회 중에 문제가 발생했습니다.');
-      }
-    }
-  };
-
-  useFocusEffect(
-    useCallback(() => {
-      fetchReviewList();
-    }, [tag]),
-  );
-
-  useEffect(() => {
-    const fetchPopularPremiumReviewList = async () => {
-      try {
-        const response = await getPopularPremiumReviews();
-        setPopularPremiumReviews(response.data.data);
-      } catch (error) {
-        console.error('인기 프리미엄 리뷰 조회 오류: ', error);
-      }
-    };
-
-    fetchPopularPremiumReviewList();
-  }, []);
 
   const tagLabelToKey: {[key: string]: string} = {
     총평만점: 'PERFECT_REVIEW',
@@ -117,7 +53,6 @@ export default function PremiumScreen() {
       const mappedTag = tagLabelToKey[tag];
       setTag(mappedTag);
     }
-    fetchReviewList(true); // 태그 바뀌면 새로 불러오기
   };
 
   return (
@@ -147,41 +82,14 @@ export default function PremiumScreen() {
           )}
         </View>
       </View>
-      <FlatList
-        data={reviewData}
-        keyExtractor={(item, index) => item.id || index.toString()}
-        onEndReached={() => {
-          if (!isFetching && hasMore) {
-            setCursor(reviewData[reviewData.length - 1]?.id || null);
-          }
-        }}
-        onEndReachedThreshold={0.5}
-        ListHeaderComponent={
-          <>
-            <View style={PremiumStyles.containerHeader}>
-              <Text style={PremiumStyles.textPopularReviewsTilte}>
-                오늘의 인기 리뷰
-              </Text>
-              <View style={PremiumStyles.containerPopularReviews}>
-                <PopularReviews popularReviews={popularPremiumReviews} />
-              </View>
-              <View style={PremiumStyles.containerTags}>
-                <Tags onTagSelect={handleTagSelect} />
-              </View>
-              {reviewData.length === 0 && (
-                <View>
-                  <Text style={PremiumStyles.noReviewText}>
-                    등록된 리뷰가 없습니다.
-                  </Text>
-                </View>
-              )}
-            </View>
-          </>
-        }
-        renderItem={({item}) => <ItemReview item={item} />}
-        ListFooterComponent={
-          isFetching && hasMore ? <ActivityIndicator size="small" /> : null
-        }
+      {/* 오늘의 인기 리뷰 */}
+      <TodayPopularReviews />
+      {/* 후기 리스트 */}
+      <ReviewLists
+        tag={tag}
+        onTagSelect={handleTagSelect}
+        isFetching={isFetching}
+        hasMore={hasMore}
       />
 
       {/* 글쓰기 버튼 */}

--- a/src/app/premium/PremiumScreen/style.tsx
+++ b/src/app/premium/PremiumScreen/style.tsx
@@ -33,7 +33,7 @@ const PremiumStyles = StyleSheet.create({
     color: Colors.gray_12,
     marginVertical: 23,
   },
-  textPopularReviewsTilte: {
+  textPopularReviewsTitle: {
     ...headline,
     marginTop: 21,
     marginBottom: 14,

--- a/src/features/premium/hooks/useReviewLists.ts
+++ b/src/features/premium/hooks/useReviewLists.ts
@@ -1,0 +1,26 @@
+import {useSuspenseQuery} from '@tanstack/react-query';
+import {getSafeTicketReviewList} from '@/api/review.api';
+
+// function useReviewLists(tag?: string) {
+//   const {data: reviewLists} = useSuspenseQuery({
+//     queryKey: ['reviewLists', tag],
+//     queryFn: ({queryKey}) => {
+//       const [, tag] = queryKey;
+//       return getTicketReviewList(100, 'createdat', undefined, tag, undefined);
+//     },
+//   });
+
+//   return {reviewLists};
+// }
+
+function useReviewLists(tag?: string) {
+  const {data: reviewLists} = useSuspenseQuery({
+    queryKey: ['reviewLists', tag],
+    queryFn: () =>
+      getSafeTicketReviewList(100, 'createdat', undefined, tag, undefined),
+  });
+
+  return {reviewLists};
+}
+
+export default useReviewLists;

--- a/src/features/premium/hooks/useReviewLists.ts
+++ b/src/features/premium/hooks/useReviewLists.ts
@@ -1,5 +1,6 @@
 import {useSuspenseQuery} from '@tanstack/react-query';
 import {getSafeTicketReviewList} from '@/api/review.api';
+import {IReviewParams} from '@/api/review.api';
 
 // function useReviewLists(tag?: string) {
 //   const {data: reviewLists} = useSuspenseQuery({
@@ -14,10 +15,15 @@ import {getSafeTicketReviewList} from '@/api/review.api';
 // }
 
 function useReviewLists(tag?: string) {
+  const params: IReviewParams = {
+    size: 100,
+    sort: 'createdat',
+    tag: tag,
+  };
+
   const {data: reviewLists} = useSuspenseQuery({
-    queryKey: ['reviewLists', tag],
-    queryFn: () =>
-      getSafeTicketReviewList(100, 'createdat', undefined, tag, undefined),
+    queryKey: ['reviewLists', params],
+    queryFn: () => getSafeTicketReviewList(params),
   });
 
   return {reviewLists};

--- a/src/features/premium/hooks/useTodayPopularReviews.ts
+++ b/src/features/premium/hooks/useTodayPopularReviews.ts
@@ -1,0 +1,13 @@
+import {useSuspenseQuery} from '@tanstack/react-query';
+import {getPopularPremiumReviews} from '@/api/premium.api';
+
+function useTodayPopularReviews() {
+  const {data: todayPopularReviews} = useSuspenseQuery({
+    queryKey: ['todayPopularReviews'],
+    queryFn: getPopularPremiumReviews,
+  });
+
+  return {todayPopularReviews};
+}
+
+export default useTodayPopularReviews;

--- a/src/features/premium/modules/ReviewLists/index.tsx
+++ b/src/features/premium/modules/ReviewLists/index.tsx
@@ -19,10 +19,9 @@ const ReviewLists: React.FC<ReviewListsProps> = ({
   hasMore,
 }) => {
   const {reviewLists} = useReviewLists(tag);
-  const data = reviewLists?.data?.data?.content ?? [];
-
-  //   console.log('ReviewLists tag:', tag);
-  //   console.log('ReviewLists data:', data);
+  const data = reviewLists?.content ?? [];
+  
+  //   console.log('ReviewLists: ', reviewLists);
 
   return (
     <>
@@ -33,22 +32,16 @@ const ReviewLists: React.FC<ReviewListsProps> = ({
       </View>
       <FlatList
         data={data}
-        keyExtractor={(item, index) => item.id?.toString() ?? index.toString()}
+        keyExtractor={(item, index) => item.review_id?.toString() ?? index.toString()}
         renderItem={({item}) => <ItemReview item={item} />}
         onEndReachedThreshold={0.5}
-        ListHeaderComponent={
-          <>
+        ListEmptyComponent={
             <View>
-              {data.length === 0 && (
-                <View>
-                  <Text style={PremiumStyles.noReviewText}>
-                    등록된 리뷰가 없습니다.
-                  </Text>
-                </View>
-              )}
+              <Text style={PremiumStyles.noReviewText}>
+                등록된 리뷰가 없습니다.
+              </Text>
             </View>
-          </>
-        }
+          }
         ListFooterComponent={
           isFetching && hasMore ? <ActivityIndicator size="small" /> : null
         }

--- a/src/features/premium/modules/ReviewLists/index.tsx
+++ b/src/features/premium/modules/ReviewLists/index.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import {FlatList, ActivityIndicator, View, Text} from 'react-native';
+import Tags from '@/components/premium/Tags';
+import ItemReview from '@/components/premium/ItemReview';
+import useReviewLists from '../../hooks/useReviewLists';
+import PremiumStyles from '@/app/premium/PremiumScreen/style';
+
+interface ReviewListsProps {
+  tag?: string;
+  onTagSelect: (tag: string) => void;
+  isFetching: boolean;
+  hasMore: boolean;
+}
+
+const ReviewLists: React.FC<ReviewListsProps> = ({
+  tag,
+  onTagSelect,
+  isFetching,
+  hasMore,
+}) => {
+  const {reviewLists} = useReviewLists(tag);
+  const data = reviewLists?.data?.data?.content ?? [];
+
+  //   console.log('ReviewLists tag:', tag);
+  //   console.log('ReviewLists data:', data);
+
+  return (
+    <>
+      <View style={PremiumStyles.containerHeader}>
+        <View style={PremiumStyles.containerTags}>
+          <Tags onTagSelect={onTagSelect} />
+        </View>
+      </View>
+      <FlatList
+        data={data}
+        keyExtractor={(item, index) => item.id?.toString() ?? index.toString()}
+        renderItem={({item}) => <ItemReview item={item} />}
+        onEndReachedThreshold={0.5}
+        ListHeaderComponent={
+          <>
+            <View>
+              {data.length === 0 && (
+                <View>
+                  <Text style={PremiumStyles.noReviewText}>
+                    등록된 리뷰가 없습니다.
+                  </Text>
+                </View>
+              )}
+            </View>
+          </>
+        }
+        ListFooterComponent={
+          isFetching && hasMore ? <ActivityIndicator size="small" /> : null
+        }
+      />
+    </>
+  );
+};
+
+export default ReviewLists;

--- a/src/features/premium/modules/TodayPopularReviews/index.tsx
+++ b/src/features/premium/modules/TodayPopularReviews/index.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import {View, Text} from 'react-native';
+import PremiumStyles from '@/app/premium/PremiumScreen/style';
+import PopularReviews from '@/components/premium/PopularReviews';
+import useTodayPopularReviews from '../../hooks/useTodayPopularReviews';
+
+
+const TodayPopularReviews: React.FC = ({
+}) => {
+  const {todayPopularReviews} = useTodayPopularReviews();
+
+  return (
+    <View style={PremiumStyles.containerHeader}>
+      <Text style={PremiumStyles.textPopularReviewsTitle}>
+        오늘의 인기 리뷰
+      </Text>
+      <View style={PremiumStyles.containerPopularReviews}>
+        <PopularReviews popularReviews={todayPopularReviews} />
+      </View>
+    </View>
+  );
+};
+
+export default TodayPopularReviews;


### PR DESCRIPTION
## #️⃣연관된 이슈

- #117 

## 📝작업 내용

- 프리미엄 홈페이지에서 컴포넌트 분리 및 usequery hook 도입
1. 오늘의 인기 리뷰 관련 컴포넌트
2. 태그별로 조회되는 프리미엄 리뷰 리스트 관련 컴포넌트

## 결과 화면

## 💬참고 사항
> - 태그별로 조회 시 빈배열 처리할 때, getSafeTicketReviewList를 추가하여 404 에러가 발생 시 빈배열로 반환해준 다음, UI에서 해당 데이터 length 0일 때 "등록된 리뷰가 없습니다"라는 방향으로 표시를 해줬습니다. 
- 해당 방식에 대해 조언을 주시면 감사하겠습니다!
